### PR TITLE
Add Cmd+Enter support for message submission

### DIFF
--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageForm.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageForm.tsx
@@ -56,7 +56,7 @@ export default function MessageForm({ onSubmit, workerId }: MessageFormProps) {
 
   const enterPost: KeyboardEventHandler = (keyEvent) => {
     if (isExecuting || isUploading) return;
-    if (keyEvent.key === 'Enter' && (keyEvent.ctrlKey || keyEvent.altKey)) {
+    if (keyEvent.key === 'Enter' && (keyEvent.ctrlKey || keyEvent.altKey || keyEvent.metaKey)) {
       handleSubmitWithAction();
     }
   };

--- a/packages/webapp/src/app/sessions/new/page.tsx
+++ b/packages/webapp/src/app/sessions/new/page.tsx
@@ -120,7 +120,7 @@ export default function NewSessionPage() {
                       onKeyDown={(e) => {
                         if (
                           e.key === 'Enter' &&
-                          (e.ctrlKey || e.altKey) &&
+                          (e.ctrlKey || e.altKey || e.metaKey) &&
                           !isExecuting &&
                           formState.isValid &&
                           !isUploading


### PR DESCRIPTION
このPRでは、MessageForm.tsxとsessions/new/page.tsxでメッセージ送信時にCmd+Enterのサポートを追加します。

## 変更点
- メッセージ送信時にCtrl+EnterまたはAlt+Enterに加えて、MacユーザーのためにCmd+Enter（metaKey）をサポート
- MessageForm.tsxとsessions/new/page.tsxの両方のキーボードイベントハンドラーを更新

## テスト
- Cmd+Enterでメッセージが送信できることを確認済み