### PR TITLE
Add PR formatting suggestion for gh pr create command

### DIFF
--- a/packages/agent-core/src/tools/command-execution/suggestion.ts
+++ b/packages/agent-core/src/tools/command-execution/suggestion.ts
@@ -5,7 +5,20 @@ export const generateSuggestion = (command: string, success: boolean): string | 
   if (command.toLowerCase().includes('gh pr create')) {
     if (success) {
       suggestion.push(
-        `Remember, when you successfully created a PR, make sure you report its URL to the user. Also check the CI status by using ${ciTool.name} tool and fix the code until it passes.`
+        `Remember, when you successfully created a PR, make sure you report its URL to the user. Also check the CI status by using ${ciTool.name} tool and fix the code until it passes.`,
+        `Please verify that your PR formatting is not broken. It's recommended to use heredoc syntax for proper markdown rendering:
+
+   gh pr edit --body "$(cat <<EOF
+   # Heading
+
+   Description text
+   
+   ## Changes
+   
+   * Item 1
+   * Item 2
+   EOF
+   )"`
       );
     }
   }


### PR DESCRIPTION
# Add PR formatting suggestion

This PR adds a suggestion for when  command is executed successfully. The suggestion reminds the user to verify PR formatting and recommends using heredoc syntax for proper markdown rendering.

## Changes

* Added a new suggestion to the  file for when  is executed successfully
* The suggestion includes example code showing how to use heredoc for proper markdown formatting