### PR TITLE
(worker): make resume more robust

### DIFF
--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -461,7 +461,7 @@ export const onMessageReceived = async (workerId: string, cancellationToken: Can
 export const resume = async (workerId: string, cancellationToken: CancellationToken) => {
   const { items } = await getConversationHistory(workerId);
   const lastItem = items.at(-1);
-  if (lastItem?.messageType == 'userMessage') {
+  if (lastItem?.messageType == 'userMessage' || lastItem?.messageType == 'toolResult') {
     return await onMessageReceived(workerId, cancellationToken);
   }
 };


### PR DESCRIPTION
## Description

This PR addresses issue #265, which aims to make the agent resume feature more robust.

### Changes
- Modified the `resume` function in `packages/worker/src/agent/index.ts` to also resume the `onMessageReceived` loop when the last message is a `toolResult`.

### Benefits
- This change ensures that the agent can recover and continue operation in more scenarios, particularly when the last interaction ended with a tool result.
- Improves the overall robustness of the system by handling an additional case for resumption.

### Implementation
The implementation is minimal and focused, simply extending the conditional check to include `toolResult` message types alongside the existing `userMessage` check.

Fixes #265

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:1751595265478499 -->

---

**Open in Web UI**: https://d2c09i1k2ray87.cloudfront.net/sessions/1751595265478499