### PR TITLE
Update README section title from 'Tenant Isolation Model' to 'Access Control (or Tenant Isolation Model)'

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ This repository can be used as a GitHub Action to automatically trigger Remote S
 
 Use `aws-samples/remote-swe-agents` in your workflow and configure your API base URL and key as repository secrets. You can generate API keys from the deployed webapp interface. See [action.yml](./action.yml) for input parameters and [.github/workflows/remote-swe.yml](./.github/workflows/remote-swe.yml) for a complete example workflow.
 
-### Tenant Isolation Model
+### Access Control (or Tenant Isolation Model)
 
 This project is currently designed as a single-tenant system, meaning it is intended to be deployed on a per-tenant basis.
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -306,7 +306,7 @@ npx cdk deploy --all
 
 ワークフローで`aws-samples/remote-swe-agents`を使用し、APIベースURLとキーをリポジトリシークレットとして設定してください。APIキーはデプロイされたwebappインターフェースから生成できます。入力パラメータについては[action.yml](./action.yml)を、完全なワークフロー例については[.github/workflows/remote-swe.yml](./.github/workflows/remote-swe.yml)を参照してください。
 
-### テナント分離モデル
+### アクセス制御（またはテナント分離モデル）
 
 このプロジェクトは現在、シングルテナントシステムとして設計されており、テナントごとにデプロイすることを想定しています。
 


### PR DESCRIPTION
## Description

This PR updates a section title in both English and Japanese versions of README:

- English: Changed `Tenant Isolation Model` to `Access Control (or Tenant Isolation Model)`
- Japanese: Changed `テナント分離モデル` to `アクセス制御（またはテナント分離モデル）`

This change makes the section title more descriptive and intuitive for readers as the section describes access control mechanisms beyond just tenant isolation.

## Changes

- Updated section title in README.md
- Updated section title in README_ja.md

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:webapp-1752215443821 -->

---

**Open in Web UI**: https://d2c09i1k2ray87.cloudfront.net/sessions/webapp-1752215443821