### PR TITLE
Add support for Claude 4.5 Sonnet and Claude 4.5 Haiku models

### DIFF
--- a/packages/agent-core/src/schema/model.ts
+++ b/packages/agent-core/src/schema/model.ts
@@ -48,7 +48,7 @@ export const modelConfigs: Record<ModelType, z.infer<typeof modelConfigSchema>> 
   'haiku4.5': {
     name: 'Claude 4.5 Haiku',
     modelId: 'anthropic.claude-haiku-4-5-20251001-v1:0',
-    maxOutputTokens: 4096,
+    maxOutputTokens: 64_000,
     maxInputTokens: 200_000,
     cacheSupport: ['system', 'message', 'tool'],
     reasoningSupport: true,


### PR DESCRIPTION
## Summary
This PR adds support for the newly released Claude 4.5 Sonnet and Claude 4.5 Haiku models from Anthropic.

## Changes
- **Added new model types**: `sonnet4.5` and `haiku4.5` to the `modelTypeList`
- **Added model configurations** with the following specifications:
  - **Claude 4.5 Sonnet**: `anthropic.claude-sonnet-4-5-20250929-v1:0`
    - Input: $0.003 per 1K tokens
    - Output: $0.015 per 1K tokens
    - Cache read: $0.0003 per 1K tokens
    - Cache write: $0.00375 per 1K tokens
  - **Claude 4.5 Haiku**: `anthropic.claude-haiku-4-5-20251001-v1:0`
    - Input: $0.001 per 1K tokens
    - Output: $0.005 per 1K tokens
    - Cache read: $0.0001 per 1K tokens
    - Cache write: $0.00125 per 1K tokens

## Model Features
Both models are configured with:
- ✅ Reasoning support
- ✅ Interleaved thinking support
- ✅ Full cache support (system, message, tool)
- ✅ Complete tool choice support (any, auto, tool)
- Token limits consistent with Claude 4 generation (200K input, 64K/4K output)

## Testing
- ✅ Build passes without errors
- ✅ All existing tests continue to pass
- ✅ No breaking changes to existing functionality

The pricing information is based on the official Anthropic pricing documentation.

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:webapp-1760587353004 -->

---

**Open in Web UI**: https://d2c09i1k2ray87.cloudfront.net/sessions/webapp-1760587353004