### PR TITLE
fix: toolUse fails when mcpServer config is empty

### DIFF
--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -166,7 +166,7 @@ const agentLoop = async (workerId: string, cancellationToken: CancellationToken)
   let firstCachePoint = initialItems.length > 2 ? initialItems.length - 3 : initialItems.length - 1;
   let secondCachePoint = 0;
   const appendedItems: typeof allItems = [];
-  let conversation = `User: ${initialMessages.findLast((msg) => msg.role == 'user')?.content?.[0].text ?? ''}\n`;
+  let conversation = `User: ${initialMessages.findLast((msg) => msg.role == 'user')?.content?.[0]?.text ?? ''}\n`;
 
   // When we get max_tokens stopReason, we double the number of max output tokens for this turn.
   // Because changing the max token count purges the prompt cache, we do not want to change it too frequently.
@@ -290,7 +290,7 @@ const agentLoop = async (workerId: string, cancellationToken: CancellationToken)
         // Extract reasoning content if available
         const reasoningBlocks = toolUseMessage.content?.filter((block) => block.reasoningContent) ?? [];
         let reasoningText: string | undefined;
-        if (reasoningBlocks.length > 0) {
+        if (reasoningBlocks[0]) {
           reasoningText = reasoningBlocks[0].reasoningContent?.reasoningText?.text;
         }
 
@@ -323,7 +323,7 @@ const agentLoop = async (workerId: string, cancellationToken: CancellationToken)
                     } else if (c.type == 'image') {
                       return {
                         image: {
-                          format: c.mimeType.split('/')[1],
+                          format: c.mimeType.split('/')[1]!,
                           source: { bytes: Buffer.from(c.data, 'base64') },
                         },
                       };

--- a/packages/worker/src/agent/mcp/index.ts
+++ b/packages/worker/src/agent/mcp/index.ts
@@ -31,13 +31,15 @@ export const getMcpToolSpecs = async (workerId: string, config: McpConfig): Prom
   if (!clientsMap[workerId]) {
     await initMcp(workerId, config);
   }
-  return clientsMap[workerId].flatMap(({ client }) => {
-    return client.tools;
-  });
+  return (
+    clientsMap[workerId]?.flatMap(({ client }) => {
+      return client.tools;
+    }) ?? []
+  );
 };
 
 export const tryExecuteMcpTool = async (workerId: string, toolName: string, input: any) => {
-  const client = clientsMap[workerId].find(({ client }) =>
+  const client = clientsMap[workerId]?.find(({ client }) =>
     client.tools.find((tool) => tool.toolSpec?.name == toolName)
   );
   if (client == null) {

--- a/packages/worker/src/entry.ts
+++ b/packages/worker/src/entry.ts
@@ -92,7 +92,7 @@ class ConverseSessionTracker {
     }
     // remove finished sessions
     for (let i = this.sessions.length - 1; i >= 0; i--) {
-      if (this.sessions[i].isFinished) {
+      if (this.sessions[i]!.isFinished) {
         this.sessions.splice(i, 1);
       }
     }

--- a/packages/worker/tsconfig.json
+++ b/packages/worker/tsconfig.json
@@ -97,7 +97,7 @@
     // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
     // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    "noUncheckedIndexedAccess": true,                    /* Add 'undefined' to a type when accessed using an index. */
     // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

When mcp config is empty, we get the below error on every tool use call.

```
TypeError: Cannot read properties of undefined (reading 'find')
at tryExecuteMcpTool (/app/packages/worker/src/agent/mcp/index.ts:40:39)
at agentLoop (/app/packages/worker/src/agent/index.ts:310:35)
at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
at async onMessageReceived (/app/packages/worker/src/agent/index.ts:447:5)
```

We enable noUncheckedIndexedAccess to avoid this error as well.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
