### PR TITLE
fix: use slash-prefixed SSM parameter name for AMI ID and fix dependency ordering

### DIFF
--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -76,6 +76,7 @@ export class MainStack extends cdk.Stack {
       : undefined;
 
     const workerAmiIdParameter = new StringParameter(this, 'WorkerAmiId', {
+      parameterName: `/${this.stackName}/worker-ami-id`,
       stringValue: 'pending-initial-build',
     });
 

--- a/cdk/lib/constructs/worker/image-builder.ts
+++ b/cdk/lib/constructs/worker/image-builder.ts
@@ -1,4 +1,4 @@
-import { ArnFormat, CfnOutput, CfnResource, CustomResource, Duration, Stack } from 'aws-cdk-lib';
+import { CfnOutput, CfnResource, CustomResource, Duration, Stack } from 'aws-cdk-lib';
 import { IVpc, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { ImagePipeline, ImagePipelineProps } from 'cdk-image-pipeline';
@@ -10,7 +10,7 @@ import { Code, Runtime, SingletonFunction } from 'aws-cdk-lib/aws-lambda';
 import { CfnImageRecipe } from 'aws-cdk-lib/aws-imagebuilder';
 import { AwsCustomResource, AwsCustomResourcePolicy, PhysicalResourceId } from 'aws-cdk-lib/custom-resources';
 import { IBucket } from 'aws-cdk-lib/aws-s3';
-import { ManagedPolicy } from 'aws-cdk-lib/aws-iam';
+import { ManagedPolicy, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { IStringParameter } from 'aws-cdk-lib/aws-ssm';
 
 export interface WorkerImageBuilderProps {
@@ -135,7 +135,7 @@ export class WorkerImageBuilder extends Construct {
       }),
     });
 
-    new AwsCustomResource(this, 'PurgeAmiCache', {
+    const purgeAmiCache = new AwsCustomResource(this, 'PurgeAmiCache', {
       onUpdate: {
         service: '@aws-sdk/client-ssm',
         action: 'PutParameter',
@@ -147,17 +147,14 @@ export class WorkerImageBuilder extends Construct {
         },
         physicalResourceId: PhysicalResourceId.of(`${amiVersion}`),
       },
-      policy: AwsCustomResourcePolicy.fromSdkCalls({
-        resources: [
-          Stack.of(this).formatArn({
-            service: 'ssm',
-            resource: 'parameter',
-            resourceName: props.amiIdParameterName.replace(/^\//, ''),
-            arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
-          }),
-        ],
-      }),
+      policy: AwsCustomResourcePolicy.fromStatements([
+        new PolicyStatement({
+          actions: ['ssm:PutParameter'],
+          resources: [props.amiIdParameter.parameterArn],
+        }),
+      ]),
     });
+    purgeAmiCache.node.addDependency(props.amiIdParameter);
 
     new CfnOutput(this, 'RemoveCachedAmiCommand', {
       value: `aws ssm put-parameter --name ${props.amiIdParameterName} --value pending-initial-build --type String --overwrite --region ${Stack.of(this).region}`,

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -2017,7 +2017,7 @@ Remote SWE Agents Team",
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:us-east-1:123456789012:parameter/",
+                    "arn:aws:ssm:us-east-1:123456789012:parameter",
                     {
                       "Ref": "WorkerAmiId428C377C",
                     },
@@ -2777,7 +2777,7 @@ exports.handler = async (event) => {
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:us-east-1:123456789012:parameter/",
+                    "arn:aws:ssm:us-east-1:123456789012:parameter",
                     {
                       "Ref": "WorkerAmiId428C377C",
                     },
@@ -4488,6 +4488,17 @@ exports.handler = async (event) => {
                   "Fn::Join": [
                     "",
                     [
+                      "arn:aws:ssm:us-east-1:123456789012:parameter",
+                      {
+                        "Ref": "WorkerAmiId428C377C",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
                       "arn:aws:ssm:us-east-1:123456789012:parameter/",
                       {
                         "Ref": "VapidKeysPrivateKeyBA530D10",
@@ -4513,17 +4524,6 @@ exports.handler = async (event) => {
                       "arn:aws:ssm:us-east-1:123456789012:parameter/",
                       {
                         "Ref": "WebappOriginNameParameterBBAD7F85",
-                      },
-                    ],
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:aws:ssm:us-east-1:123456789012:parameter/",
-                      {
-                        "Ref": "WorkerAmiId428C377C",
                       },
                     ],
                   ],
@@ -5394,6 +5394,7 @@ exports.handler = async (event) => {
     },
     "WorkerAmiId428C377C": {
       "Properties": {
+        "Name": "/TestMainStack/worker-ami-id",
         "Type": "String",
         "Value": "pending-initial-build",
       },
@@ -6922,6 +6923,7 @@ phases:
       "DeletionPolicy": "Delete",
       "DependsOn": [
         "WorkerImageBuilderPurgeAmiCacheCustomResourcePolicy864B61A7",
+        "WorkerAmiId428C377C",
       ],
       "Properties": {
         "Create": {
@@ -6960,6 +6962,9 @@ phases:
       "UpdateReplacePolicy": "Delete",
     },
     "WorkerImageBuilderPurgeAmiCacheCustomResourcePolicy864B61A7": {
+      "DependsOn": [
+        "WorkerAmiId428C377C",
+      ],
       "Properties": {
         "PolicyDocument": {
           "Statement": [
@@ -6970,7 +6975,7 @@ phases:
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:us-east-1:123456789012:parameter/",
+                    "arn:aws:ssm:us-east-1:123456789012:parameter",
                     {
                       "Ref": "WorkerAmiId428C377C",
                     },


### PR DESCRIPTION
## Summary

Fixes EC2 runtime not working after deployment because the AMI ID SSM parameter was never updated by Image Builder.

## Root Cause

PR #395 changed the AMI ID SSM parameter from a user-provided name (with leading slash like `/remote-swe/xxx/ami-id`) to a CDK auto-generated name without a leading slash (e.g. `CFN-WorkerAmiId-xxx`).

The `cdk-image-pipeline` library builds IAM policy ARNs by concatenating `parameter` + `ssmPath`. Without a leading slash, the ARN becomes `parameterCFN-...` instead of `parameter/CFN-...`, causing the update Lambda to fail with `AccessDeniedException`.

Additionally, the `PurgeAmiCache` custom resource had no explicit dependency on the IAM policy update, causing race conditions during stack updates.

## Changes

**`cdk/lib/cdk-stack.ts`**
- Set explicit `parameterName: /${this.stackName}/worker-ami-id` with leading slash

**`cdk/lib/constructs/worker/image-builder.ts`**
- Replace `fromSdkCalls` with `fromStatements` using `parameterArn` directly (proper CDK dependency tracking)
- Add explicit dependency: `purgeAmiCache.node.addDependency(props.amiIdParameter)`
- Clean up unused `ArnFormat` import

## Verification
- Deployed successfully to test environment
- SSM parameter created as `/RemoteSweStack-test/worker-ami-id`
- PurgeAmiCache executed without AccessDeniedException

## Note for existing deployments
This changes the SSM parameter name, so the parameter will be recreated. The Image Builder pipeline will be triggered to rebuild the AMI and update the new parameter.