### PR TITLE
fix: grant InvokeAgentRuntime permission to worker role for child session creation

### DIFF
--- a/cdk/lib/constructs/worker/agent-core-runtime.ts
+++ b/cdk/lib/constructs/worker/agent-core-runtime.ts
@@ -1,4 +1,4 @@
-import { CfnOutput, Names, Stack } from 'aws-cdk-lib';
+import { Arn, ArnFormat, CfnOutput, Names, Stack } from 'aws-cdk-lib';
 import { CfnRuntime } from 'aws-cdk-lib/aws-bedrockagentcore';
 import { ITableV2 } from 'aws-cdk-lib/aws-dynamodb';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
@@ -148,6 +148,21 @@ export class AgentCoreRuntime extends Construct implements IGrantable {
     runtime.node.addDependency(role);
 
     this.runtimeArn = runtime.attrAgentRuntimeArn;
+
+    // Grant the worker role itself permission to invoke this runtime
+    // so that agents can create child sessions via InvokeAgentRuntimeCommand.
+    // Use wildcard ARN pattern to avoid circular dependency between the role and the runtime.
+    const runtimeArnPattern = Arn.format(
+      { service: 'bedrock-agentcore', resource: 'runtime', resourceName: '*', arnFormat: ArnFormat.SLASH_RESOURCE_NAME },
+      Stack.of(this)
+    );
+    role.addToPrincipalPolicy(
+      new PolicyStatement({
+        actions: ['bedrock-agentcore:InvokeAgentRuntime'],
+        resources: [runtimeArnPattern, `${runtimeArnPattern}/runtime-endpoint/DEFAULT`],
+      })
+    );
+
     new CfnOutput(this, 'RuntimeArn', { value: this.runtimeArn });
   }
 

--- a/cdk/lib/constructs/worker/agent-core-runtime.ts
+++ b/cdk/lib/constructs/worker/agent-core-runtime.ts
@@ -153,7 +153,12 @@ export class AgentCoreRuntime extends Construct implements IGrantable {
     // so that agents can create child sessions via InvokeAgentRuntimeCommand.
     // Use wildcard ARN pattern to avoid circular dependency between the role and the runtime.
     const runtimeArnPattern = Arn.format(
-      { service: 'bedrock-agentcore', resource: 'runtime', resourceName: '*', arnFormat: ArnFormat.SLASH_RESOURCE_NAME },
+      {
+        service: 'bedrock-agentcore',
+        resource: 'runtime',
+        resourceName: '*',
+        arnFormat: ArnFormat.SLASH_RESOURCE_NAME,
+      },
       Stack.of(this)
     );
     role.addToPrincipalPolicy(

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -5122,6 +5122,14 @@ exports.handler = async (event) => {
               },
             },
             {
+              "Action": "bedrock-agentcore:InvokeAgentRuntime",
+              "Effect": "Allow",
+              "Resource": [
+                "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/*",
+                "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/*/runtime-endpoint/DEFAULT",
+              ],
+            },
+            {
               "Action": [
                 "scheduler:CreateSchedule",
                 "scheduler:DeleteSchedule",


### PR DESCRIPTION
## Problem

When an agent running on the Agent Core runtime tries to create a child session using the `createNewSession` tool, the `InvokeAgentRuntimeCommand` call fails because the worker role lacks the `bedrock-agentcore:InvokeAgentRuntime` permission.

## Solution

Grant the worker role `bedrock-agentcore:InvokeAgentRuntime` permission on the runtime resource. 

To avoid a circular dependency between the IAM role and the runtime resource (the role needs to reference the runtime ARN, but the runtime depends on the role), a wildcard ARN pattern is used via `Arn.format()` instead of referencing `runtime.attrAgentRuntimeArn` directly.

The permission includes both the runtime resource itself and the `runtime-endpoint/DEFAULT` sub-resource, which is required for the actual invocation.

## Changes

- Added `Arn` and `ArnFormat` imports from `aws-cdk-lib`
- Added IAM policy statement granting `bedrock-agentcore:InvokeAgentRuntime` to the worker role with a wildcard ARN pattern