### PR TITLE
fix: align Slack async handler default runtimeType with agent-core default

### DIFF
--- a/packages/slack-bolt-app/src/async-handler.ts
+++ b/packages/slack-bolt-app/src/async-handler.ts
@@ -43,7 +43,7 @@ export const handler: Handler<unknown> = async (rawEvent, context) => {
       await makeIdempotent(
         async (_: string) => {
           const session = await getSession(event.workerId);
-          const runtimeType = session?.runtimeType ?? 'ec2';
+          const runtimeType = session?.runtimeType ?? 'agent-core';
           const res = await getOrCreateWorkerInstance(event.workerId, runtimeType);
 
           if (res.oldStatus == 'stopped') {


### PR DESCRIPTION
## Problem

The Slack async handler in `packages/slack-bolt-app/src/async-handler.ts` uses `'ec2'` as the fallback `runtimeType` when a session has no explicit runtime type set. However, the `defaultAgentConfig.runtimeType` is `'agent-core'`, creating an inconsistency.

This means sessions created via Slack without an explicit runtime type would default to EC2 instead of Agent Core.

## Fix

Changed the fallback value from `'ec2'` to `'agent-core'` to align with the default agent configuration.