### PR TITLE
fix: rename eventTrigger label to Event Detected

### DIFF
--- a/packages/webapp/src/messages/en.json
+++ b/packages/webapp/src/messages/en.json
@@ -55,7 +55,7 @@
     "noSessionsFound": "No sessions found",
     "createSessionToStart": "Create a new session to start chatting with AI agents",
     "usingTool": "Using Tool",
-    "eventTriggerFired": "Event Trigger",
+    "eventTriggerFired": "Event Detected",
     "executing": "Executing...",
     "showRawJson": "Show raw JSON",
     "hideRawJson": "Hide raw JSON",

--- a/packages/webapp/src/messages/ja.json
+++ b/packages/webapp/src/messages/ja.json
@@ -55,7 +55,7 @@
     "noSessionsFound": "セッションが見つかりません",
     "createSessionToStart": "AIエージェントとチャットするには新規セッションを作成してください",
     "usingTool": "ツール使用",
-    "eventTriggerFired": "イベントトリガー",
+    "eventTriggerFired": "イベント検知",
     "executing": "実行中...",
     "showRawJson": "JSONを表示",
     "hideRawJson": "JSONを隠す",


### PR DESCRIPTION
## Problem

The `eventTriggerFired` label displayed "Event Trigger" / "イベントトリガー" in the webapp UI. This wording is not descriptive enough for users — it should indicate that an event was detected rather than just naming the trigger mechanism.

## Fix

Renamed the i18n labels:
- English: `Event Trigger` → `Event Detected`
- Japanese: `イベントトリガー` → `イベント検知`

## Changed Files
- `packages/webapp/src/messages/en.json`
- `packages/webapp/src/messages/ja.json`