### PR TITLE
fix: reconnect EventBus WebSocket on page visibility change

### DIFF
--- a/packages/webapp/src/hooks/use-event-bus.ts
+++ b/packages/webapp/src/hooks/use-event-bus.ts
@@ -68,7 +68,7 @@ export const useEventBus = ({ channelName, onReceived, onConnected, onError }: U
 
     const onVisibilityChange = () => {
       if (document.visibilityState === 'visible' && isMounted) {
-        console.log('Page became visible, reconnecting EventBus...');
+        console.debug('Page became visible, reconnecting EventBus...');
         if (channel) {
           channel.close();
           channel = null;

--- a/packages/webapp/src/hooks/use-event-bus.ts
+++ b/packages/webapp/src/hooks/use-event-bus.ts
@@ -31,29 +31,59 @@ Amplify.configure(
 type UseEventBusProps = {
   channelName: string;
   onReceived: (payload: unknown) => void;
+  onConnected?: () => void;
+  onError?: (err: unknown) => void;
 };
 
-export const useEventBus = ({ channelName, onReceived }: UseEventBusProps) => {
+export const useEventBus = ({ channelName, onReceived, onConnected, onError }: UseEventBusProps) => {
   useEffect(() => {
-    const connectAndSubscribe = async () => {
-      const channel = await events.connect(`event-bus/${channelName}`);
-      console.log(`subscribing channel ${channelName}`);
+    let channel: Awaited<ReturnType<typeof events.connect>> | null = null;
+    let isMounted = true;
 
-      channel.subscribe({
-        next: (data) => {
-          onReceived(data.event);
-        },
-        error: (err) => console.error('error', err),
-      });
-      return channel;
+    const connectAndSubscribe = async () => {
+      try {
+        const ch = await events.connect(`event-bus/${channelName}`);
+        if (!isMounted) {
+          ch.close();
+          return;
+        }
+        channel = ch;
+        ch.subscribe({
+          next: (data) => {
+            onReceived(data.event);
+          },
+          error: (err) => {
+            console.error('EventBus error:', err);
+            onError?.(err);
+          },
+        });
+        onConnected?.();
+      } catch (err) {
+        console.error('EventBus connect error:', err);
+        onError?.(err);
+      }
     };
 
-    const pr = connectAndSubscribe();
+    connectAndSubscribe();
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible' && isMounted) {
+        console.log('Page became visible, reconnecting EventBus...');
+        if (channel) {
+          channel.close();
+          channel = null;
+        }
+        connectAndSubscribe();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
 
     return () => {
-      pr.then((channel) => {
+      isMounted = false;
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      if (channel) {
         channel.close();
-      });
+      }
     };
-  }, [channelName, onReceived]);
+  }, [channelName, onReceived, onConnected, onError]);
 };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

On iOS (and other mobile browsers), when the device sleeps and wakes up, the
EventBus WebSocket connection silently dies but the app doesn't detect the
disconnection. This leaves the session page without real-time updates.

Fix by listening for the `visibilitychange` event and reconnecting the WebSocket
when the page becomes visible again. Also adds `onConnected` and `onError`
callbacks to the `useEventBus` hook, and properly tracks the mounted state to
prevent stale connections.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
