### PR TITLE
feat: add key parameter support to agent-icon API route

### DIFF
--- a/packages/webapp/src/app/api/agent-icon/route.ts
+++ b/packages/webapp/src/app/api/agent-icon/route.ts
@@ -7,8 +7,16 @@ export const dynamic = 'force-dynamic';
 
 export async function GET(request: NextRequest) {
   try {
-    const preferences = await getPreferences();
-    const iconKey = preferences.defaultAgentIconKey;
+    // Support explicit key parameter for custom agent icons
+    const keyParam = request.nextUrl.searchParams.get('key');
+    let iconKey: string | undefined;
+
+    if (keyParam) {
+      iconKey = keyParam;
+    } else {
+      const preferences = await getPreferences();
+      iconKey = preferences.defaultAgentIconKey;
+    }
 
     if (!iconKey) {
       return NextResponse.redirect(new URL('/icon-192x192.png', request.url));

--- a/packages/webapp/src/app/custom-agent/components/AgentIconPreview.tsx
+++ b/packages/webapp/src/app/custom-agent/components/AgentIconPreview.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
 import { Bot } from 'lucide-react';
-import { getImageUrls } from '@/actions/image/action';
 
 type AgentIconPreviewProps = {
   iconKey?: string;
@@ -10,19 +8,8 @@ type AgentIconPreviewProps = {
 };
 
 export default function AgentIconPreview({ iconKey, size = 32 }: AgentIconPreviewProps) {
-  const [iconUrl, setIconUrl] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (iconKey) {
-      getImageUrls({ keys: [iconKey] }).then((result) => {
-        if (result?.data && result.data.length > 0) {
-          setIconUrl(result.data[0].url);
-        }
-      });
-    }
-  }, [iconKey]);
-
-  if (iconUrl) {
+  if (iconKey) {
+    const iconUrl = `/api/agent-icon?key=${encodeURIComponent(iconKey)}`;
     return (
       /* eslint-disable-next-line @next/next/no-img-element */
       <img

--- a/packages/webapp/src/components/AgentIconUploader.tsx
+++ b/packages/webapp/src/components/AgentIconUploader.tsx
@@ -4,7 +4,6 @@ import { useState, useRef, ChangeEvent, useEffect } from 'react';
 import { Loader2, Upload, X } from 'lucide-react';
 import { toast } from 'sonner';
 import { getUploadUrl } from '@/actions/upload/action';
-import { getImageUrls } from '@/actions/image/action';
 
 type AgentIconUploaderProps = {
   currentIconKey?: string;
@@ -25,11 +24,7 @@ export default function AgentIconUploader({
 
   useEffect(() => {
     if (currentIconKey) {
-      getImageUrls({ keys: [currentIconKey] }).then((result) => {
-        if (result?.data && result.data.length > 0) {
-          setPreviewUrl(result.data[0].url);
-        }
-      });
+      setPreviewUrl(`/api/agent-icon?key=${encodeURIComponent(currentIconKey)}`);
     }
   }, [currentIconKey]);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add support for an explicit `key` query parameter to the agent-icon API route,
enabling custom agent icons to be served through the same endpoint.

Previously, AgentIconPreview and AgentIconUploader used presigned S3 URLs
(via getImageUrls) to display agent icons. This changes them to use the
`/api/agent-icon?key=` route instead, which simplifies the components by
removing async state management and provides a consistent icon serving path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
