### PR TITLE
fix: complete missing toolResults on cancellation and repair partial toolResults

### DIFF
--- a/packages/agent-core/src/lib/messages.ts
+++ b/packages/agent-core/src/lib/messages.ts
@@ -120,6 +120,46 @@ export const repairDanglingToolUse = async (workerId: string, items: MessageItem
         );
         console.log(`Repaired dangling toolUse at SK=${item.SK} with dummy toolResult at SK=${toolResultItem.SK}`);
         repaired.push(toolResultItem);
+      } else {
+        // Check for PARTIAL toolResult (some toolUseIds missing from the toolResult message)
+        const toolUseContent = JSON.parse(item.content);
+        const toolResultContent = JSON.parse(next.content);
+        const toolUseIds = new Set<string>(
+          toolUseContent
+            .filter((c: any) => c.toolUse?.toolUseId)
+            .map((c: any) => c.toolUse.toolUseId as string)
+        );
+        const toolResultIds = new Set<string>(
+          toolResultContent
+            .filter((c: any) => c.toolResult?.toolUseId)
+            .map((c: any) => c.toolResult.toolUseId as string)
+        );
+        const missingIds = [...toolUseIds].filter((id) => !toolResultIds.has(id));
+        if (missingIds.length > 0) {
+          for (const missingId of missingIds) {
+            toolResultContent.push({
+              toolResult: {
+                toolUseId: missingId,
+                content: [
+                  {
+                    text: 'This tool execution was interrupted and no result is available.',
+                  },
+                ],
+              },
+            });
+          }
+          const updatedContent = JSON.stringify(toolResultContent);
+          await ddb.send(
+            new PutCommand({
+              TableName,
+              Item: { ...next, content: updatedContent },
+            })
+          );
+          console.log(
+            `Repaired partial toolResult at SK=${next.SK}: added ${missingIds.length} missing result(s) for toolUseIds: ${missingIds.join(', ')}`
+          );
+          next.content = updatedContent;
+        }
       }
     }
   }

--- a/packages/agent-core/src/lib/messages.ts
+++ b/packages/agent-core/src/lib/messages.ts
@@ -125,9 +125,7 @@ export const repairDanglingToolUse = async (workerId: string, items: MessageItem
         const toolUseContent = JSON.parse(item.content);
         const toolResultContent = JSON.parse(next.content);
         const toolUseIds = new Set<string>(
-          toolUseContent
-            .filter((c: any) => c.toolUse?.toolUseId)
-            .map((c: any) => c.toolUse.toolUseId as string)
+          toolUseContent.filter((c: any) => c.toolUse?.toolUseId).map((c: any) => c.toolUse.toolUseId as string)
         );
         const toolResultIds = new Set<string>(
           toolResultContent

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -406,9 +406,7 @@ const agentLoop = async (workerId: string, cancellationToken: CancellationToken)
         for (const request of toolUseRequests) {
           const toolUseId = request.toolUse?.toolUseId;
           if (toolUseId == null) continue;
-          const alreadyHasResult = toolResultMessage.content!.some(
-            (c) => c.toolResult?.toolUseId === toolUseId
-          );
+          const alreadyHasResult = toolResultMessage.content!.some((c) => c.toolResult?.toolUseId === toolUseId);
           if (!alreadyHasResult) {
             console.log(`Filling missing toolResult for cancelled tool: ${request.toolUse?.name} (${toolUseId})`);
             toolResultMessage.content!.push({

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -396,6 +396,33 @@ const agentLoop = async (workerId: string, cancellationToken: CancellationToken)
           toolUseId: toolUseId,
           output: toolResult ? toolResult : (toolResultObject?.map((r) => r.text).join('\n') ?? ''),
         });
+
+        // Check cancellation after each tool execution to stop early
+        if (cancellationToken.isCancelled) break;
+      }
+
+      // Fill in missing tool results for tools that were not executed due to cancellation
+      if (cancellationToken.isCancelled) {
+        for (const request of toolUseRequests) {
+          const toolUseId = request.toolUse?.toolUseId;
+          if (toolUseId == null) continue;
+          const alreadyHasResult = toolResultMessage.content!.some(
+            (c) => c.toolResult?.toolUseId === toolUseId
+          );
+          if (!alreadyHasResult) {
+            console.log(`Filling missing toolResult for cancelled tool: ${request.toolUse?.name} (${toolUseId})`);
+            toolResultMessage.content!.push({
+              toolResult: {
+                toolUseId,
+                content: [
+                  {
+                    text: 'This tool execution was skipped because the agent session was interrupted by a new incoming message.',
+                  },
+                ],
+              },
+            });
+          }
+        }
       }
 
       // Save toolResult message to DynamoDB after all tools have been executed


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When an agent session is cancelled (e.g. by an incoming message) while executing
parallel tool calls, only the results of already-executed tools are saved to
DynamoDB. The missing toolResult entries cause a permanent conversation history
corruption ('Expected toolResult blocks for IDs' error on every subsequent request).

Fix 1 (prevention): After each tool execution, check the cancellation token and
break early. Then fill in dummy toolResult entries for any tools that were not
executed before saving to DynamoDB.

Fix 2 (recovery): Extend repairDanglingToolUse to detect and repair partial
toolResult messages where the number of toolResult entries doesn't match the
number of toolUse entries in the preceding message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
