### PR TITLE
fix: resolve executeCommand promise immediately on cancellation without killing process

### DIFF
--- a/packages/agent-core/src/private/common/lib.ts
+++ b/packages/agent-core/src/private/common/lib.ts
@@ -2,6 +2,10 @@ import { Tool, ToolResultContentBlock } from '@aws-sdk/client-bedrock-runtime';
 import z, { ZodType } from 'zod';
 import { GlobalPreferences } from '../../schema';
 
+export interface CancellationToken {
+  readonly isCancelled: boolean;
+}
+
 export type ToolDefinition<Input> = {
   /**
    * Name of the tool. This is the identifier of the tool for the agent.
@@ -9,7 +13,7 @@ export type ToolDefinition<Input> = {
   readonly name: string;
   readonly handler: (
     input: Input,
-    context: { workerId: string; toolUseId: string; globalPreferences: GlobalPreferences }
+    context: { workerId: string; toolUseId: string; globalPreferences: GlobalPreferences; cancellationToken?: CancellationToken }
   ) => Promise<string | ToolResultContentBlock[]>;
   readonly schema: ZodType<Input>;
   readonly toolSpec: () => Promise<NonNullable<Tool['toolSpec']>>;

--- a/packages/agent-core/src/private/common/lib.ts
+++ b/packages/agent-core/src/private/common/lib.ts
@@ -13,7 +13,12 @@ export type ToolDefinition<Input> = {
   readonly name: string;
   readonly handler: (
     input: Input,
-    context: { workerId: string; toolUseId: string; globalPreferences: GlobalPreferences; cancellationToken?: CancellationToken }
+    context: {
+      workerId: string;
+      toolUseId: string;
+      globalPreferences: GlobalPreferences;
+      cancellationToken?: CancellationToken;
+    }
   ) => Promise<string | ToolResultContentBlock[]>;
   readonly schema: ZodType<Input>;
   readonly toolSpec: () => Promise<NonNullable<Tool['toolSpec']>>;

--- a/packages/agent-core/src/tools/command-execution/index.test.ts
+++ b/packages/agent-core/src/tools/command-execution/index.test.ts
@@ -11,14 +11,7 @@ describe('executeCommand with cancellationToken', () => {
     const cancellationToken = { isCancelled: false };
 
     const startTime = Date.now();
-    const resultPromise = executeCommand(
-      'sleep 300',
-      undefined,
-      60000,
-      false,
-      undefined,
-      cancellationToken
-    );
+    const resultPromise = executeCommand('sleep 300', undefined, 60000, false, undefined, cancellationToken);
 
     await new Promise((resolve) => setTimeout(resolve, 200));
     (cancellationToken as any).isCancelled = true;
@@ -79,7 +72,11 @@ describe('executeCommand with cancellationToken', () => {
     // Cleanup: kill the background process using PID from result
     const pidMatch = result.error?.match(/PID: (\d+)/);
     if (pidMatch) {
-      try { process.kill(parseInt(pidMatch[1]!, 10), 'SIGTERM'); } catch { /* already exited */ }
+      try {
+        process.kill(parseInt(pidMatch[1]!, 10), 'SIGTERM');
+      } catch {
+        /* already exited */
+      }
     }
     // Also kill by marker just in case
     await executeCommand(`pkill -f "${marker}" || true`, undefined, 5000);
@@ -88,14 +85,7 @@ describe('executeCommand with cancellationToken', () => {
   test('completes normally when not cancelled', async () => {
     const cancellationToken = { isCancelled: false };
 
-    const result = await executeCommand(
-      'echo hello',
-      undefined,
-      60000,
-      false,
-      undefined,
-      cancellationToken
-    );
+    const result = await executeCommand('echo hello', undefined, 60000, false, undefined, cancellationToken);
 
     expect(result.stdout).toContain('hello');
     expect(result.error).toBeUndefined();
@@ -111,14 +101,7 @@ describe('executeCommand with cancellationToken', () => {
   test('cancellation resolves rather than rejects', async () => {
     const cancellationToken = { isCancelled: false };
 
-    const resultPromise = executeCommand(
-      'sleep 300',
-      undefined,
-      60000,
-      false,
-      undefined,
-      cancellationToken
-    );
+    const resultPromise = executeCommand('sleep 300', undefined, 60000, false, undefined, cancellationToken);
 
     await new Promise((resolve) => setTimeout(resolve, 200));
     (cancellationToken as any).isCancelled = true;

--- a/packages/agent-core/src/tools/command-execution/index.test.ts
+++ b/packages/agent-core/src/tools/command-execution/index.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test, vi } from 'vitest';
+import { executeCommand } from './index';
+
+vi.mock('./github', () => ({
+  authorizeGitHubCli: async () => undefined,
+  isGitHubConfigured: () => false,
+}));
+
+describe('executeCommand with cancellationToken', () => {
+  test('resolves immediately on cancellation without killing the process', async () => {
+    const cancellationToken = { isCancelled: false };
+
+    const startTime = Date.now();
+    const resultPromise = executeCommand(
+      'sleep 300',
+      undefined,
+      60000,
+      false,
+      undefined,
+      cancellationToken
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    (cancellationToken as any).isCancelled = true;
+
+    const result = await resultPromise;
+    const elapsed = Date.now() - startTime;
+
+    expect(result.error).toContain('still running in background');
+    expect(result.error).toContain('PID:');
+    // Should resolve quickly, not wait for the 300s sleep
+    expect(elapsed).toBeLessThan(3000);
+  }, 10000);
+
+  test('includes partial stdout and PID in cancellation result', async () => {
+    const cancellationToken = { isCancelled: false };
+
+    const resultPromise = executeCommand(
+      'echo hello && sleep 300',
+      undefined,
+      60000,
+      false,
+      undefined,
+      cancellationToken
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    (cancellationToken as any).isCancelled = true;
+
+    const result = await resultPromise;
+    expect(result.stdout).toContain('hello');
+    expect(result.error).toContain('PID:');
+    expect(result.error).toContain('still running in background');
+  }, 10000);
+
+  test('process continues running after cancellation', async () => {
+    const cancellationToken = { isCancelled: false };
+    const marker = `rswealive${Date.now()}`;
+
+    const resultPromise = executeCommand(
+      `bash -c 'while true; do sleep 1; done' # ${marker}`,
+      undefined,
+      60000,
+      false,
+      undefined,
+      cancellationToken
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    (cancellationToken as any).isCancelled = true;
+
+    const result = await resultPromise;
+
+    // Process should still be running
+    const checkResult = await executeCommand(`ps aux | grep "${marker}" | grep -v grep | wc -l`, undefined, 5000);
+    const count = parseInt(checkResult.stdout.trim(), 10);
+    expect(count).toBeGreaterThan(0);
+
+    // Cleanup: kill the background process using PID from result
+    const pidMatch = result.error?.match(/PID: (\d+)/);
+    if (pidMatch) {
+      try { process.kill(parseInt(pidMatch[1]!, 10), 'SIGTERM'); } catch { /* already exited */ }
+    }
+    // Also kill by marker just in case
+    await executeCommand(`pkill -f "${marker}" || true`, undefined, 5000);
+  }, 15000);
+
+  test('completes normally when not cancelled', async () => {
+    const cancellationToken = { isCancelled: false };
+
+    const result = await executeCommand(
+      'echo hello',
+      undefined,
+      60000,
+      false,
+      undefined,
+      cancellationToken
+    );
+
+    expect(result.stdout).toContain('hello');
+    expect(result.error).toBeUndefined();
+  }, 10000);
+
+  test('works without cancellationToken (backward compatibility)', async () => {
+    const result = await executeCommand('echo test');
+
+    expect(result.stdout).toContain('test');
+    expect(result.error).toBeUndefined();
+  }, 10000);
+
+  test('cancellation resolves rather than rejects', async () => {
+    const cancellationToken = { isCancelled: false };
+
+    const resultPromise = executeCommand(
+      'sleep 300',
+      undefined,
+      60000,
+      false,
+      undefined,
+      cancellationToken
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    (cancellationToken as any).isCancelled = true;
+
+    await expect(resultPromise).resolves.toBeDefined();
+  }, 10000);
+
+  test('timeout after cancellation does not kill the process or remove PID file', async () => {
+    const cancellationToken = { isCancelled: false };
+    const marker = `rswetimeout${Date.now()}`;
+
+    // Use a very short timeout so it fires quickly after cancellation
+    const resultPromise = executeCommand(
+      `bash -c 'while true; do sleep 1; done' # ${marker}`,
+      undefined,
+      1000, // 1 second timeout
+      false,
+      undefined,
+      cancellationToken
+    );
+
+    // Wait for process to start, then cancel
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    (cancellationToken as any).isCancelled = true;
+
+    const result = await resultPromise;
+    expect(result.error).toContain('still running in background');
+
+    // Wait longer than the timeout (1s) to let it fire if it was going to
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    // Process should STILL be running — timeout must not have killed it
+    const checkResult = await executeCommand(`ps aux | grep "${marker}" | grep -v grep | wc -l`, undefined, 5000);
+    const count = parseInt(checkResult.stdout.trim(), 10);
+    expect(count).toBeGreaterThan(0);
+
+    // Cleanup
+    await executeCommand(`pkill -f "${marker}" || true`, undefined, 5000);
+  }, 15000);
+});

--- a/packages/agent-core/src/tools/command-execution/index.ts
+++ b/packages/agent-core/src/tools/command-execution/index.ts
@@ -5,7 +5,7 @@ import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 import { mkdirSync, writeFileSync, unlinkSync } from 'fs';
 import { z } from 'zod';
-import { ToolDefinition, truncate, zodToJsonSchemaBody } from '../../private/common/lib';
+import { CancellationToken, ToolDefinition, truncate, zodToJsonSchemaBody } from '../../private/common/lib';
 import { generateSuggestion } from './suggestion';
 
 const inputSchema = z.object({
@@ -50,7 +50,8 @@ export const executeCommand = async (
   cwd?: string,
   timeoutMs = 60000,
   longRunningProcess = false,
-  toolUseId?: string
+  toolUseId?: string,
+  cancellationToken?: CancellationToken
 ) => {
   // Ignore error when github token is not available
   const token = await authorizeGitHubCli().catch((e) => console.log(e));
@@ -83,15 +84,37 @@ export const executeCommand = async (
     let stderr = '';
     let timer: NodeJS.Timeout;
     let longRunningTimer: NodeJS.Timeout | undefined;
+    let cancellationInterval: NodeJS.Timeout | undefined;
     let hasExited = false;
+    let resolved = false;
+
+    const safeResolve = (result: {
+      stdout: string;
+      stderr: string;
+      error?: string;
+      exitCode?: number;
+      suggestion?: string;
+      isLongRunning?: boolean;
+    }) => {
+      if (!resolved) {
+        resolved = true;
+        resolve(result);
+      }
+    };
 
     const resetTimer = () => {
+      if (resolved) return;
       clearTimeout(timer);
       timer = setTimeout(() => {
-        // Only kill the process if it's not a long-running one
-        if (!longRunningProcess) {
+        // Only kill the process if it's not a long-running one and not already resolved
+        if (!longRunningProcess && !resolved) {
+          clearTimeout(timer);
+          if (longRunningTimer) clearTimeout(longRunningTimer);
+          if (cancellationInterval) clearInterval(cancellationInterval);
+          hasExited = true;
+          if (toolUseId) removePidFile(toolUseId);
           childProcess.kill();
-          resolve({
+          safeResolve({
             error: `Command execution timed out after ${Math.round(timeoutMs / 1000)} seconds of inactivity`,
             stdout: truncate(stdout, 40e3),
             stderr: truncate(stderr),
@@ -108,7 +131,7 @@ export const executeCommand = async (
       longRunningTimer = setTimeout(() => {
         if (!hasExited) {
           console.log(`Returning control to agent after 10 seconds for long-running process: ${command}`);
-          resolve({
+          safeResolve({
             stdout: truncate(stdout, 40e3),
             stderr: truncate(stderr),
             isLongRunning: true,
@@ -118,12 +141,31 @@ export const executeCommand = async (
       }, 10000); // 10 seconds
     }
 
+    if (cancellationToken) {
+      cancellationInterval = setInterval(() => {
+        if (cancellationToken.isCancelled && !hasExited) {
+          console.log(`Cancellation requested, leaving process running in background for command: ${command} (PID: ${childProcess.pid})`);
+          clearTimeout(timer);
+          if (longRunningTimer) clearTimeout(longRunningTimer);
+          clearInterval(cancellationInterval!);
+          // Do NOT kill the process — let it continue in background
+          // Do NOT remove PID file — process is still running
+          safeResolve({
+            stdout: truncate(stdout, 40e3),
+            stderr: truncate(stderr),
+            error: `Command is still running in background (PID: ${childProcess.pid}). The agent session was interrupted by a new incoming message.`,
+          });
+        }
+      }, 100);
+    }
+
     childProcess.on('error', (error) => {
       clearTimeout(timer);
       if (longRunningTimer) clearTimeout(longRunningTimer);
+      if (cancellationInterval) clearInterval(cancellationInterval);
       hasExited = true;
       if (toolUseId) removePidFile(toolUseId);
-      resolve({
+      safeResolve({
         error: `Failed to interact with the process: ${error.message}`,
         stdout: truncate(stdout, 40e3),
         stderr: truncate(stderr),
@@ -132,11 +174,13 @@ export const executeCommand = async (
     });
 
     childProcess.stdout.on('data', (data) => {
+      if (resolved) return;
       stdout += data.toString();
       resetTimer();
     });
 
     childProcess.stderr.on('data', (data) => {
+      if (resolved) return;
       stderr += data.toString();
       resetTimer();
     });
@@ -144,19 +188,20 @@ export const executeCommand = async (
     childProcess.on('close', (code) => {
       clearTimeout(timer);
       if (longRunningTimer) clearTimeout(longRunningTimer);
+      if (cancellationInterval) clearInterval(cancellationInterval);
       hasExited = true;
       if (toolUseId) removePidFile(toolUseId);
 
       // If the process exits within the 10 seconds window for long-running processes,
       // we should report that instead of leaving it running
       if (code === 0) {
-        resolve({
+        safeResolve({
           stdout: truncate(stdout, 40e3),
           stderr: truncate(stderr),
           suggestion: generateSuggestion(command, true),
         });
       } else {
-        resolve({
+        safeResolve({
           error: `Command failed with exit code ${code}`,
           exitCode: code!,
           stdout: truncate(stdout, 40e3),
@@ -170,7 +215,7 @@ export const executeCommand = async (
 
 const handler = async (
   input: { command: string; cwd?: string; longRunningProcess?: boolean; timeoutMs?: number },
-  context: { toolUseId: string }
+  context: { toolUseId: string; cancellationToken?: CancellationToken }
 ) => {
   // Validate that timeoutMs and longRunningProcess are not used together
   if (input.timeoutMs !== undefined && input.longRunningProcess === true) {
@@ -184,7 +229,8 @@ const handler = async (
     input.cwd,
     input.timeoutMs ?? 60000,
     input.longRunningProcess,
-    context.toolUseId
+    context.toolUseId,
+    context.cancellationToken
   );
   return JSON.stringify(res, undefined, 1);
 };

--- a/packages/agent-core/src/tools/command-execution/index.ts
+++ b/packages/agent-core/src/tools/command-execution/index.ts
@@ -144,7 +144,9 @@ export const executeCommand = async (
     if (cancellationToken) {
       cancellationInterval = setInterval(() => {
         if (cancellationToken.isCancelled && !hasExited) {
-          console.log(`Cancellation requested, leaving process running in background for command: ${command} (PID: ${childProcess.pid})`);
+          console.log(
+            `Cancellation requested, leaving process running in background for command: ${command} (PID: ${childProcess.pid})`
+          );
           clearTimeout(timer);
           if (longRunningTimer) clearTimeout(longRunningTimer);
           clearInterval(cancellationInterval!);

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -360,7 +360,7 @@ const agentLoop = async (workerId: string, cancellationToken: CancellationToken)
             }
 
             console.log(`using tool: ${name} ${JSON.stringify(input)}`);
-            const result = await tool.handler(input as any, { toolUseId, workerId, globalPreferences });
+            const result = await tool.handler(input as any, { toolUseId, workerId, globalPreferences, cancellationToken });
             if (typeof result == 'string') {
               toolResult = result;
             } else {

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -360,7 +360,12 @@ const agentLoop = async (workerId: string, cancellationToken: CancellationToken)
             }
 
             console.log(`using tool: ${name} ${JSON.stringify(input)}`);
-            const result = await tool.handler(input as any, { toolUseId, workerId, globalPreferences, cancellationToken });
+            const result = await tool.handler(input as any, {
+              toolUseId,
+              workerId,
+              globalPreferences,
+              cancellationToken,
+            });
             if (typeof result == 'string') {
               toolResult = result;
             } else {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When an agent session is cancelled (e.g. by an incoming message from another
agent), the executeCommand tool previously killed the running child process.
This caused issues with long-running daemons and background processes.

Instead, resolve the Promise immediately on cancellation while letting the
process continue running in the background. Also prevent the timeout handler
from killing the process after cancellation has already occurred.

Changes:
- Add CancellationToken interface to tool handler context
- Implement safeResolve pattern to prevent double-resolution
- Add 7 unit tests covering cancellation scenarios
- Pass cancellationToken from agent loop to tool handlers
- 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
