### PR TITLE
feat: add multi-agent communication with parent-child session grouping

### DIFF
--- a/packages/agent-core/src/lib/agent-messaging.ts
+++ b/packages/agent-core/src/lib/agent-messaging.ts
@@ -1,0 +1,137 @@
+import { PutCommand } from '@aws-sdk/lib-dynamodb';
+import { ddb, TableName } from './aws';
+import { getSession } from './sessions';
+import { sendWorkerEvent, sendWebappEvent } from './events';
+import { getOrCreateWorkerInstance } from './worker-manager';
+import { renderAgentMessage } from './prompt';
+import { getCustomAgent } from './custom-agent';
+import { getPreferences } from './preferences';
+import { MessageItem, SessionItem } from '../schema';
+
+/**
+ * Resolve the display name for a session's agent.
+ * Priority: agentName > custom agent name > default agent name > title > "Assistant"
+ */
+export async function resolveAgentDisplayName(session: SessionItem): Promise<string> {
+  if (session.agentName) return session.agentName;
+
+  if (session.customAgentId) {
+    const customAgent = await getCustomAgent(session.customAgentId);
+    if (customAgent?.name) return customAgent.name;
+  }
+
+  const prefs = await getPreferences();
+  if (prefs.defaultAgentName) return prefs.defaultAgentName;
+
+  return session.title || 'Assistant';
+}
+
+export interface SendAgentMessageParams {
+  senderWorkerId: string;
+  targetSessionIds: string[];
+  message: string;
+  /** If true, message is saved but target worker is NOT woken up */
+  acknowledge?: boolean;
+}
+
+export interface SendAgentMessageResult {
+  sent: string[];
+  failed: { sessionId: string; reason: string }[];
+}
+
+/**
+ * Send a message from one agent session to one or more target sessions.
+ * No routing restrictions - any session can message any other session by ID.
+ */
+export async function sendAgentMessage(params: SendAgentMessageParams): Promise<SendAgentMessageResult> {
+  const { senderWorkerId, targetSessionIds, message, acknowledge } = params;
+
+  const senderSession = await getSession(senderWorkerId);
+  if (!senderSession) {
+    return { sent: [], failed: targetSessionIds.map((id) => ({ sessionId: id, reason: 'Sender session not found' })) };
+  }
+
+  const senderName = await resolveAgentDisplayName(senderSession);
+  const result: SendAgentMessageResult = { sent: [], failed: [] };
+
+  for (const targetId of targetSessionIds) {
+    try {
+      if (targetId === senderWorkerId) {
+        result.failed.push({ sessionId: targetId, reason: 'Cannot send message to self' });
+        continue;
+      }
+
+      const targetSession = await getSession(targetId);
+      if (!targetSession) {
+        result.failed.push({ sessionId: targetId, reason: 'Session not found' });
+        continue;
+      }
+
+      const now = Date.now();
+      const wrappedMessage = `[Message from ${senderName} (${senderWorkerId})]: ${message}`;
+      const content = [{ text: renderAgentMessage({ message: wrappedMessage, senderSessionId: senderWorkerId }) }];
+
+      const targetName = await resolveAgentDisplayName(targetSession);
+
+      const item: MessageItem = {
+        PK: `message-${targetId}`,
+        SK: String(now).padStart(15, '0'),
+        content: JSON.stringify(content),
+        role: 'user',
+        tokenCount: 0,
+        messageType: 'agentMessage',
+        senderSessionId: senderWorkerId,
+        senderAgentName: senderName,
+        targetSessionId: targetId,
+        targetAgentName: targetName,
+        isAcknowledge: acknowledge,
+      };
+
+      await ddb.send(new PutCommand({ TableName, Item: item }));
+
+      // Notify the parent session's webapp about the communication (for communication log)
+      const parentSessionId = senderSession.parentSessionId || targetSession.parentSessionId;
+      if (parentSessionId && parentSessionId !== targetId) {
+        // Persist the agent message in the parent session's history so it survives page reload
+        const parentItem: MessageItem = {
+          PK: `message-${parentSessionId}`,
+          SK: String(now + 1).padStart(15, '0'),
+          content: JSON.stringify([{ text: message }]),
+          role: 'user',
+          tokenCount: 0,
+          messageType: 'agentMessage',
+          senderSessionId: senderWorkerId,
+          senderAgentName: senderName,
+          targetSessionId: targetId,
+          targetAgentName: targetName,
+          isAcknowledge: acknowledge,
+        };
+        await ddb.send(new PutCommand({ TableName, Item: parentItem }));
+
+        await sendWebappEvent(parentSessionId, {
+          type: 'agentMessage',
+          senderSessionId: senderWorkerId,
+          senderName,
+          targetSessionId: targetId,
+          targetName,
+          message,
+          acknowledge: acknowledge ?? false,
+        });
+      }
+
+      if (!acknowledge) {
+        // Wake up the target worker to process the message
+        const runtimeType = targetSession.runtimeType ?? 'agent-core';
+        await getOrCreateWorkerInstance(targetId, runtimeType);
+        await sendWorkerEvent(targetId, { type: 'onMessageReceived' });
+      }
+
+      result.sent.push(targetId);
+    } catch (e) {
+      console.error(`[agent-messaging] Error sending to ${targetId}:`, e);
+      result.failed.push({ sessionId: targetId, reason: (e as Error).message });
+    }
+  }
+
+  return result;
+}

--- a/packages/agent-core/src/lib/agent-messaging.ts
+++ b/packages/agent-core/src/lib/agent-messaging.ts
@@ -91,23 +91,27 @@ export async function sendAgentMessage(params: SendAgentMessageParams): Promise<
 
       // Notify the parent session's webapp about the communication (for communication log)
       const parentSessionId = senderSession.parentSessionId || targetSession.parentSessionId;
-      if (parentSessionId && parentSessionId !== targetId) {
-        // Persist the agent message in the parent session's history so it survives page reload
-        const parentItem: MessageItem = {
-          PK: `message-${parentSessionId}`,
-          SK: String(now + 1).padStart(15, '0'),
-          content: JSON.stringify([{ text: message }]),
-          role: 'user',
-          tokenCount: 0,
-          messageType: 'agentMessage',
-          senderSessionId: senderWorkerId,
-          senderAgentName: senderName,
-          targetSessionId: targetId,
-          targetAgentName: targetName,
-          isAcknowledge: acknowledge,
-        };
-        await ddb.send(new PutCommand({ TableName, Item: parentItem }));
+      if (parentSessionId) {
+        if (parentSessionId !== targetId) {
+          // Persist the agent message in the parent session's history so it survives page reload
+          // Only for sibling-to-sibling messages; child-to-parent messages are already stored in the target (parent) history
+          const parentItem: MessageItem = {
+            PK: `message-${parentSessionId}`,
+            SK: String(now + 1).padStart(15, '0'),
+            content: JSON.stringify([{ text: message }]),
+            role: 'user',
+            tokenCount: 0,
+            messageType: 'agentMessage',
+            senderSessionId: senderWorkerId,
+            senderAgentName: senderName,
+            targetSessionId: targetId,
+            targetAgentName: targetName,
+            isAcknowledge: acknowledge,
+          };
+          await ddb.send(new PutCommand({ TableName, Item: parentItem }));
+        }
 
+        // Always send real-time webapp notification to the parent session
         await sendWebappEvent(parentSessionId, {
           type: 'agentMessage',
           senderSessionId: senderWorkerId,

--- a/packages/agent-core/src/lib/converse.ts
+++ b/packages/agent-core/src/lib/converse.ts
@@ -53,7 +53,9 @@ export const bedrockConverse = async (
   maxTokensExceededCount = 0
 ): Promise<{ response: ConverseResponse; thinkingBudget?: number }> => {
   if (maxTokensExceededCount > 5) {
-    throw new Error(`Max tokens exceeded too many times (${maxTokensExceededCount})`);
+    throw new Error(
+      `Max tokens exceeded too many times (${maxTokensExceededCount}). The model output consistently exceeds the maximum output token limit. Please reduce output length significantly.`
+    );
   }
   try {
     const modelType = chooseRandom(modelTypes);

--- a/packages/agent-core/src/lib/create-session.ts
+++ b/packages/agent-core/src/lib/create-session.ts
@@ -1,12 +1,15 @@
 import { TransactWriteCommand } from '@aws-sdk/lib-dynamodb';
+import { PutCommand } from '@aws-sdk/lib-dynamodb';
 import { ddb, TableName } from './aws';
 import { MessageItem, ModelType, RuntimeType, SessionItem, defaultAgentConfig } from '../schema';
 import { getOrCreateWorkerInstance, updateInstanceStatus } from './worker-manager';
 import { sendWorkerEvent } from './events';
 import { getCustomAgent } from './custom-agent';
-import { renderUserMessage } from './prompt';
+import { renderUserMessage, renderAgentMessage, renderSystemNotification } from './prompt';
 import { postNewSlackThread } from './slack';
 import { getWebappSessionUrl } from './webapp-origin';
+import { getChildSessions, getSession } from './sessions';
+import { resolveAgentDisplayName } from './agent-messaging';
 import { randomBytes } from 'crypto';
 
 export interface CreateSessionParams {
@@ -14,7 +17,9 @@ export interface CreateSessionParams {
   initiator: string;
   customAgentId?: string;
   title?: string;
+  agentName?: string;
   modelOverride?: ModelType;
+  parentSessionId?: string;
   imageKeys?: string[];
   fileKeys?: string[];
   /**
@@ -26,6 +31,12 @@ export interface CreateSessionParams {
    * Slack user ID to mention in the new thread notification.
    */
   slackMentionUserId?: string;
+  /**
+   * Session ID that created this session (for independent sessions).
+   * Unlike parentSessionId (which establishes parent-child hierarchy),
+   * this simply records who created the session so it can send messages back.
+   */
+  creatorSessionId?: string;
 }
 
 /**
@@ -39,11 +50,14 @@ export const createSession = async (params: CreateSessionParams): Promise<string
     initiator,
     customAgentId,
     title,
+    agentName,
     modelOverride,
+    parentSessionId,
     imageKeys = [],
     fileKeys = [],
     slackChannelId,
     slackMentionUserId,
+    creatorSessionId,
   } = params;
   const agent = await getCustomAgent(customAgentId);
   const runtimeType: RuntimeType = agent?.runtimeType ?? defaultAgentConfig.runtimeType;
@@ -57,7 +71,13 @@ export const createSession = async (params: CreateSessionParams): Promise<string
   }
 
   const now = Date.now();
-  const content: any[] = [{ text: renderUserMessage({ message }) }];
+  const content: any[] = [
+    {
+      text: parentSessionId
+        ? renderAgentMessage({ message, senderSessionId: parentSessionId })
+        : renderUserMessage({ message }),
+    },
+  ];
   for (const key of imageKeys) {
     content.push({
       image: {
@@ -94,6 +114,19 @@ export const createSession = async (params: CreateSessionParams): Promise<string
     }
   }
 
+  // Resolve parent agent name for child sessions
+  let parentAgentName: string | undefined;
+  if (parentSessionId) {
+    try {
+      const parentSession = await getSession(parentSessionId);
+      if (parentSession) {
+        parentAgentName = await resolveAgentDisplayName(parentSession);
+      }
+    } catch (e) {
+      console.error('Failed to resolve parent agent name:', e);
+    }
+  }
+
   await ddb.send(
     new TransactWriteCommand({
       TransactItems: [
@@ -115,6 +148,9 @@ export const createSession = async (params: CreateSessionParams): Promise<string
               customAgentId: agent?.SK,
               runtimeType,
               ...(title ? { title } : {}),
+              ...(agentName ? { agentName } : {}),
+              ...(parentSessionId ? { parentSessionId } : {}),
+              ...(creatorSessionId ? { creatorSessionId } : {}),
               ...(slackChannelId ? { slackChannelId } : {}),
               ...(slackThreadTs ? { slackThreadTs } : {}),
             } satisfies SessionItem,
@@ -129,8 +165,10 @@ export const createSession = async (params: CreateSessionParams): Promise<string
               content: JSON.stringify(content),
               role: 'user',
               tokenCount: 0,
-              messageType: 'userMessage',
+              messageType: parentSessionId ? 'agentMessage' : 'userMessage',
               ...(modelOverride ? { modelOverride } : {}),
+              ...(parentSessionId ? { senderSessionId: parentSessionId } : {}),
+              ...(parentAgentName ? { senderAgentName: parentAgentName } : {}),
             } satisfies MessageItem,
           },
         },
@@ -144,6 +182,36 @@ export const createSession = async (params: CreateSessionParams): Promise<string
   } catch (e) {
     await updateInstanceStatus(workerId, 'terminated');
     throw e;
+  }
+
+  // Notify existing sibling sessions about the new child
+  if (parentSessionId) {
+    try {
+      const siblings = await getChildSessions(parentSessionId);
+      const displayName = agentName || title || workerId;
+      for (const sibling of siblings) {
+        if (sibling.workerId === workerId) continue;
+        const notifyContent = [
+          {
+            text: renderSystemNotification({
+              message: `A new sibling session has joined: "${displayName}" (ID: ${workerId}). You can communicate with it using sendMessageToAgent.`,
+            }),
+          },
+        ];
+        const notifyItem: MessageItem = {
+          PK: `message-${sibling.workerId}`,
+          SK: String(Date.now()).padStart(15, '0'),
+          content: JSON.stringify(notifyContent),
+          role: 'user',
+          tokenCount: 0,
+          messageType: 'eventTrigger',
+        };
+        await ddb.send(new PutCommand({ TableName, Item: notifyItem }));
+        await sendWorkerEvent(sibling.workerId, { type: 'onMessageReceived' });
+      }
+    } catch (e) {
+      console.error('Failed to notify sibling sessions:', e);
+    }
   }
 
   return workerId;

--- a/packages/agent-core/src/lib/index.ts
+++ b/packages/agent-core/src/lib/index.ts
@@ -5,6 +5,7 @@ export * from './metadata';
 export * from './converse';
 export * from './sessions';
 export * from './create-session';
+export * from './agent-messaging';
 export * from './worker-id';
 export * from './worker-manager';
 export * from './events';

--- a/packages/agent-core/src/lib/prompt.ts
+++ b/packages/agent-core/src/lib/prompt.ts
@@ -2,13 +2,19 @@ import { reportProgressTool } from '../tools/report-progress';
 import { PutCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
 import { ddb, TableName } from './aws/ddb';
 
-export const renderToolResult = (props: { toolResult: string; forceReport: boolean }) => {
+export const renderToolResult = (props: { toolResult: string; forceReport: boolean; parentSessionId?: string }) => {
+  let forceReportMessage = '';
+  if (props.forceReport) {
+    forceReportMessage = props.parentSessionId
+      ? `Long time has passed since you sent the last message. Please use sendMessageToAgent tool to report progress to the parent (session ID: ${props.parentSessionId}).`
+      : `Long time has passed since you sent the last message. Please use ${reportProgressTool.name} tool to send a response asap.`;
+  }
   return `
 <result>
 ${props.toolResult}
 </result>
 <command>
-${props.forceReport ? `Long time has passed since you sent the last message. Please use ${reportProgressTool.name} tool to send a response asap.` : ''}
+${forceReportMessage}
 </command>
 `.trim();
 };
@@ -20,6 +26,27 @@ ${props.message}
 </user_message>
 <command>
 User sent you a message. Please use ${reportProgressTool.name} tool to send a response asap.
+</command>
+`.trim();
+};
+
+export const renderAgentMessage = (props: { message: string; senderSessionId: string }) => {
+  return `
+<user_message>
+${props.message}
+</user_message>
+<command>
+An agent sent you a message. Please use sendMessageToAgent tool to reply to the sender (session ID: ${props.senderSessionId}).
+</command>
+`.trim();
+};
+
+export const renderSystemNotification = (props: { message: string }) => {
+  return `
+<user_message>
+${props.message}
+</user_message>
+<command>
 </command>
 `.trim();
 };

--- a/packages/agent-core/src/lib/sessions.ts
+++ b/packages/agent-core/src/lib/sessions.ts
@@ -122,10 +122,77 @@ export const updateSessionLastMessage = async (workerId: string, lastMessage: st
 };
 
 /**
- * Delete a session and all related data (messages, metadata) from DynamoDB
+ * Get direct child sessions of a parent session
+ * @param parentWorkerId Worker ID of the parent session
+ * @returns Array of child SessionItems
+ */
+export const getChildSessions = async (parentWorkerId: string): Promise<SessionItem[]> => {
+  const allSessions = await getSessions(0);
+  return allSessions.filter((s) => s.parentSessionId === parentWorkerId);
+};
+
+/**
+ * Get all descendant sessions (children, grandchildren, etc.) recursively
+ * @param parentWorkerId Worker ID of the root parent session
+ * @returns Array of all descendant SessionItems
+ */
+export const getDescendantSessions = async (parentWorkerId: string): Promise<SessionItem[]> => {
+  const allSessions = await getAllSessionsIncludingChildren();
+  const descendants: SessionItem[] = [];
+  const collect = (parentId: string) => {
+    const children = allSessions.filter((s) => s.parentSessionId === parentId);
+    for (const child of children) {
+      descendants.push(child);
+      collect(child.workerId);
+    }
+  };
+  collect(parentWorkerId);
+  return descendants;
+};
+
+/**
+ * Get all sessions including those with parentSessionId (no isHidden filter)
+ */
+export const getAllSessionsIncludingChildren = async (): Promise<SessionItem[]> => {
+  const paginator = paginateQuery(
+    { client: ddb },
+    {
+      TableName,
+      IndexName: 'LSI1',
+      KeyConditionExpression: 'PK = :pk',
+      ExpressionAttributeValues: { ':pk': 'sessions' },
+      ScanIndexForward: false,
+    }
+  );
+  const items: SessionItem[] = [];
+  for await (const page of paginator) {
+    if (page.Items != null) {
+      items.push(...(page.Items as SessionItem[]));
+    }
+  }
+  return items;
+};
+
+/**
+ * Delete a session and all related data (messages, metadata) from DynamoDB.
+ * Also recursively deletes all descendant (child, grandchild, etc.) sessions.
  * @param workerId Worker ID of the session to delete
  */
 export const deleteSession = async (workerId: string): Promise<void> => {
+  // Recursively delete all descendant sessions first
+  const descendants = await getDescendantSessions(workerId);
+  for (const child of descendants) {
+    await deleteSingleSession(child.workerId);
+  }
+
+  // Delete the session itself
+  await deleteSingleSession(workerId);
+};
+
+/**
+ * Delete a single session and its related data (without recursive child deletion)
+ */
+const deleteSingleSession = async (workerId: string): Promise<void> => {
   // Clean up all EventBridge triggers associated with this session
   try {
     await deleteAllEventTriggers(workerId);

--- a/packages/agent-core/src/schema/agent.ts
+++ b/packages/agent-core/src/schema/agent.ts
@@ -3,6 +3,7 @@ import { ModelType, modelTypeSchema } from './model';
 
 export const agentStatusSchema = z.union([z.literal('working'), z.literal('pending'), z.literal('completed')]);
 export const runtimeTypeSchema = z.union([z.literal('ec2'), z.literal('agent-core')]);
+export const defaultRuntimeType: RuntimeType = 'agent-core';
 
 export type AgentStatus = z.infer<typeof agentStatusSchema>;
 export type RuntimeType = z.infer<typeof runtimeTypeSchema>;

--- a/packages/agent-core/src/schema/events.ts
+++ b/packages/agent-core/src/schema/events.ts
@@ -80,4 +80,15 @@ export const webappEventSchema = z.discriminatedUnion('type', [
     hasPending: z.boolean(),
     timestamp: z.number(),
   }),
+  z.object({
+    type: z.literal('agentMessage'),
+    senderSessionId: z.string(),
+    senderName: z.string(),
+    targetSessionId: z.string(),
+    targetName: z.string(),
+    message: z.string(),
+    acknowledge: z.boolean(),
+    timestamp: z.number(),
+    workerId: z.string(),
+  }),
 ]);

--- a/packages/agent-core/src/schema/message.ts
+++ b/packages/agent-core/src/schema/message.ts
@@ -22,4 +22,24 @@ export type MessageItem = {
    */
   thinkingBudget?: number;
   modelOverride?: ModelType;
+  /**
+   * Session ID of the agent that sent this message (for agent-to-agent communication)
+   */
+  senderSessionId?: string;
+  /**
+   * Display name of the sender agent
+   */
+  senderAgentName?: string;
+  /**
+   * Session ID of the target agent that received this message (for agent-to-agent communication)
+   */
+  targetSessionId?: string;
+  /**
+   * Display name of the target agent
+   */
+  targetAgentName?: string;
+  /**
+   * Whether this is an acknowledge (non-waking) message
+   */
+  isAcknowledge?: boolean;
 };

--- a/packages/agent-core/src/schema/session.ts
+++ b/packages/agent-core/src/schema/session.ts
@@ -30,6 +30,9 @@ export const sessionItemSchema = z.object({
   lastMessageAt: z.number().optional(),
   customAgentId: z.string().optional(),
   runtimeType: runtimeTypeSchema.optional(),
+  parentSessionId: z.string().optional(),
+  creatorSessionId: z.string().optional(),
+  agentName: z.string().optional(),
 });
 
 export type SessionItem = z.infer<typeof sessionItemSchema>;

--- a/packages/agent-core/src/tools/acknowledge-agent/index.ts
+++ b/packages/agent-core/src/tools/acknowledge-agent/index.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+import { ToolDefinition, zodToJsonSchemaBody } from '../../private/common/lib';
+import { sendAgentMessage } from '../../lib/agent-messaging';
+
+const inputSchema = z.object({
+  targetSessionIds: z.array(z.string()).min(1).describe('One or more session IDs to acknowledge.'),
+  message: z
+    .string()
+    .min(1)
+    .describe(
+      'A short acknowledgement message (e.g. "Got it, working on it." or "Task complete, here are the results: ...").'
+    ),
+});
+
+const name = 'acknowledgeAgent';
+
+export const acknowledgeAgentTool: ToolDefinition<z.infer<typeof inputSchema>> = {
+  name,
+  handler: async (input: z.infer<typeof inputSchema>, context) => {
+    const result = await sendAgentMessage({
+      senderWorkerId: context.workerId,
+      targetSessionIds: input.targetSessionIds,
+      message: input.message,
+      acknowledge: true,
+    });
+
+    const lines: string[] = [];
+    if (result.sent.length > 0) {
+      lines.push(`Acknowledged to: ${result.sent.join(', ')} (message saved, agent NOT woken up)`);
+    }
+    for (const f of result.failed) {
+      lines.push(`Failed to acknowledge ${f.sessionId}: ${f.reason}`);
+    }
+    return lines.join('\n') || 'No acknowledgements sent.';
+  },
+  schema: inputSchema,
+  toolSpec: async () => ({
+    name,
+    description: `Send an acknowledgement message to another agent session WITHOUT waking up the target agent.
+The message is saved in the target's conversation history but does NOT trigger a new agent turn.
+This is like a Slack reaction — the target will see it next time they wake up, but won't be interrupted.
+
+Use this instead of sendMessageToAgent when:
+- You want to confirm receipt without triggering a response loop
+- The conversation has reached a natural stopping point
+- You're providing a final status update that doesn't need immediate action`,
+    inputSchema: {
+      json: zodToJsonSchemaBody(inputSchema),
+    },
+  }),
+};

--- a/packages/agent-core/src/tools/confirm-send-to-user/index.ts
+++ b/packages/agent-core/src/tools/confirm-send-to-user/index.ts
@@ -1,0 +1,51 @@
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { writeFileSync, readFileSync, unlinkSync } from 'fs';
+import { z } from 'zod';
+import { ToolDefinition, zodToJsonSchemaBody } from '../../private/common/lib';
+import { sendMessageToUser } from '../report-progress';
+
+const PENDING_DIR = tmpdir();
+
+const pendingFilePath = (workerId: string) => join(PENDING_DIR, `.pending-user-message-${workerId}`);
+
+export const savePendingUserMessage = (workerId: string, message: string) => {
+  writeFileSync(pendingFilePath(workerId), message, 'utf-8');
+};
+
+export const loadAndDeletePendingUserMessage = (workerId: string): string | undefined => {
+  const filePath = pendingFilePath(workerId);
+  try {
+    const message = readFileSync(filePath, 'utf-8');
+    unlinkSync(filePath);
+    return message;
+  } catch {
+    return undefined;
+  }
+};
+
+const inputSchema = z.object({});
+
+const name = 'confirmSendToUser';
+
+export const confirmSendToUserTool: ToolDefinition<z.infer<typeof inputSchema>> = {
+  name,
+  handler: async (_input: z.infer<typeof inputSchema>, context) => {
+    const pendingMessage = loadAndDeletePendingUserMessage(context.workerId);
+
+    if (!pendingMessage) {
+      return 'No pending message to confirm. Use sendMessageToUser first.';
+    }
+
+    await sendMessageToUser(context.workerId, pendingMessage);
+    return 'Successfully sent the message to the user.';
+  },
+  schema: inputSchema,
+  toolSpec: async () => ({
+    name,
+    description: `Confirm and send a blocked sendMessageToUser call in a child session. Call this after sendMessageToUser returns a confirmation prompt. If you do not want to send the message, simply do not call this tool.`,
+    inputSchema: {
+      json: zodToJsonSchemaBody(inputSchema),
+    },
+  }),
+};

--- a/packages/agent-core/src/tools/create-session/index.ts
+++ b/packages/agent-core/src/tools/create-session/index.ts
@@ -10,6 +10,25 @@ const inputSchema = z.object({
     .min(1)
     .describe('The initial message to send to the new session. This should clearly describe the task or topic.'),
   title: z.string().max(50).optional().describe('Optional title for the new session.'),
+  agentName: z
+    .string()
+    .max(30)
+    .optional()
+    .describe(
+      'A display name for the new session\'s agent (e.g. "Frontend Dev", "Test Runner"). Used to identify the agent in inter-agent communication. Recommended when creating child sessions.'
+    ),
+  customAgentId: z
+    .string()
+    .optional()
+    .describe(
+      "ID of a custom agent to use for the new session. If omitted, the new session inherits the current session's agent configuration. Use listAgents to find available agent IDs."
+    ),
+  asChild: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, the new session is created as a child of the CURRENT session (automatically uses the current session ID as the parent). This groups related sessions together and aggregates child messages in the parent chat view. Default: false (independent session).'
+    ),
 });
 
 const name = 'createNewSession';
@@ -28,11 +47,17 @@ export const createNewSessionTool: ToolDefinition<z.infer<typeof inputSchema>> =
       slackMentionUserId = initiator.replace('slack#', '');
     }
 
+    const parentSessionId = input.asChild ? context.workerId : undefined;
+    const creatorSessionId = !input.asChild ? context.workerId : undefined;
+
     const workerId = await createSession({
       message: input.message,
       initiator,
-      customAgentId: currentSession.customAgentId,
+      customAgentId: input.customAgentId || currentSession.customAgentId,
       title: input.title,
+      agentName: input.agentName,
+      parentSessionId,
+      creatorSessionId,
       slackChannelId: currentSession.slackChannelId,
       slackMentionUserId,
     });
@@ -43,7 +68,10 @@ export const createNewSessionTool: ToolDefinition<z.infer<typeof inputSchema>> =
       ? '\n- Slack: A new thread has been created in the same channel'
       : '';
 
-    return `New session created successfully.\n- Session ID: ${workerId}\n- Title: ${input.title ?? '(auto-generated)'}\n- Message: ${input.message}${urlInfo}${slackInfo}`;
+    const parentInfo = parentSessionId ? `\n- Parent Session: ${parentSessionId}` : '';
+    const nameInfo = input.agentName ? `\n- Agent Name: ${input.agentName}` : '';
+
+    return `New session created successfully.\n- Session ID: ${workerId}\n- Title: ${input.title ?? '(auto-generated)'}${nameInfo}\n- Message: ${input.message}${parentInfo}${urlInfo}${slackInfo}`;
   },
   schema: inputSchema,
   toolSpec: async () => ({
@@ -64,7 +92,25 @@ export const createNewSessionTool: ToolDefinition<z.infer<typeof inputSchema>> =
 - The new session inherits the current session's agent configuration (custom agent, runtime type, etc.)
 - If the current session is linked to Slack, a new thread will be created in the same Slack channel
 - The new session will start processing the message immediately after creation
-- You will receive the new session ID in the response`,
+- You will receive the new session ID in the response
+- Use asChild=true to group related sessions together (e.g. sub-tasks of a larger task). The parent session's chat view will show messages from child sessions. Leave it false or omit for completely independent sessions.
+- When creating child sessions, provide a descriptive 'agentName' so sibling agents can identify each other (e.g. "Frontend Dev", "Backend Dev").
+- Use 'customAgentId' to assign a specific custom agent configuration to the new session (use listAgents to find IDs).
+
+## Child vs Independent Session Guidelines:
+- **Child session (asChild=true)**: Use ONLY when the task is a sub-task of your current session. The parent acts as a coordinator/relay. Choose this when:
+  - The task is tightly coupled to the parent session's context
+  - The parent needs to aggregate or coordinate the results
+  - The sub-task's progress should be visible in the parent's chat view
+- **Independent session (asChild=false or omitted)**: Use when the task can stand on its own. Choose this when:
+  - The task is unrelated or loosely related to the current session
+  - The new session needs to communicate directly with the user
+  - The parent session may become idle/sleep and shouldn't block the new session
+
+## Decision criteria:
+- Is the task tightly dependent on the parent session's context? → Child
+- Can the task complete independently without parent coordination? → Independent
+- Does the new session need direct user communication? → Independent`,
     inputSchema: {
       json: zodToJsonSchemaBody(inputSchema),
     },

--- a/packages/agent-core/src/tools/index.ts
+++ b/packages/agent-core/src/tools/index.ts
@@ -52,7 +52,14 @@ export const gitHubTools = [
  * Required tools that are always enabled regardless of custom agent tool selection.
  * These tools are essential for basic agent functionality.
  */
-export const requiredTools = [reportProgressTool, todoInitTool, todoUpdateTool, sendFileTool, updateSessionTitleTool, confirmSendToUserTool];
+export const requiredTools = [
+  reportProgressTool,
+  todoInitTool,
+  todoUpdateTool,
+  sendFileTool,
+  updateSessionTitleTool,
+  confirmSendToUserTool,
+];
 
 /**
  * Required tool names for filtering convenience.

--- a/packages/agent-core/src/tools/index.ts
+++ b/packages/agent-core/src/tools/index.ts
@@ -11,6 +11,7 @@ export * from './report-progress';
 export * from './send-file';
 export * from './send-to-agent';
 export * from './acknowledge-agent';
+export * from './confirm-send-to-user';
 export * from './think';
 export * from './read-image';
 export * from './todo';
@@ -29,6 +30,7 @@ import { reportProgressTool } from './report-progress';
 import { sendFileTool } from './send-file';
 import { sendToAgentTool } from './send-to-agent';
 import { acknowledgeAgentTool } from './acknowledge-agent';
+import { confirmSendToUserTool } from './confirm-send-to-user';
 import { readImageTool } from './read-image';
 import { todoInitTool, todoUpdateTool } from './todo';
 import { updateSessionTitleTool } from './session-title';
@@ -50,7 +52,7 @@ export const gitHubTools = [
  * Required tools that are always enabled regardless of custom agent tool selection.
  * These tools are essential for basic agent functionality.
  */
-export const requiredTools = [reportProgressTool, todoInitTool, todoUpdateTool, sendFileTool, updateSessionTitleTool];
+export const requiredTools = [reportProgressTool, todoInitTool, todoUpdateTool, sendFileTool, updateSessionTitleTool, confirmSendToUserTool];
 
 /**
  * Required tool names for filtering convenience.

--- a/packages/agent-core/src/tools/index.ts
+++ b/packages/agent-core/src/tools/index.ts
@@ -9,6 +9,8 @@ export * from './manage-agent';
 export * from './repo';
 export * from './report-progress';
 export * from './send-file';
+export * from './send-to-agent';
+export * from './acknowledge-agent';
 export * from './think';
 export * from './read-image';
 export * from './todo';
@@ -25,6 +27,8 @@ import { listAgentsTool, getAgentTool, createAgentTool, updateAgentTool, deleteA
 import { cloneRepositoryTool } from './repo';
 import { reportProgressTool } from './report-progress';
 import { sendFileTool } from './send-file';
+import { sendToAgentTool } from './send-to-agent';
+import { acknowledgeAgentTool } from './acknowledge-agent';
 import { readImageTool } from './read-image';
 import { todoInitTool, todoUpdateTool } from './todo';
 import { updateSessionTitleTool } from './session-title';
@@ -63,6 +67,8 @@ export const optionalTools = [
   fileEditTool,
   readImageTool,
   createNewSessionTool,
+  sendToAgentTool,
+  acknowledgeAgentTool,
   listAgentsTool,
   getAgentTool,
   createAgentTool,

--- a/packages/agent-core/src/tools/report-progress/index.test.ts
+++ b/packages/agent-core/src/tools/report-progress/index.test.ts
@@ -77,7 +77,7 @@ describe('sendMessageToUser child session confirmation', () => {
     expect(mockSendMessageToSlack).toHaveBeenCalledWith('reply to user');
   });
 
-  test('child session with triggering message as agentMessage returns confirmation prompt', async () => {
+  test('child session with triggering message as agentMessage and user messages returns strong warning with confirmSendToUser', async () => {
     mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
     mockGetConversationHistory.mockResolvedValue({
       items: [
@@ -92,14 +92,16 @@ describe('sendMessageToUser child session confirmation', () => {
 
     const result = await reportProgressTool.handler({ message: 'blocked message' }, mockContext);
 
-    expect(result).toContain('This is a child session');
+    expect(result).toContain('WARNING');
+    expect(result).toContain('99%');
     expect(result).toContain('Messages from user in this session: 1');
     expect(result).toContain('agentMessage (PM Agent)');
     expect(result).toContain('confirmSendToUser');
+    expect(result).toContain('ABSOLUTELY CERTAIN');
     expect(mockSendMessageToSlack).not.toHaveBeenCalled();
   });
 
-  test('child session with triggering message as eventTrigger returns confirmation prompt', async () => {
+  test('child session with triggering message as eventTrigger and no user messages returns hard error', async () => {
     mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
     mockGetConversationHistory.mockResolvedValue({
       items: [
@@ -111,13 +113,15 @@ describe('sendMessageToUser child session confirmation', () => {
 
     const result = await reportProgressTool.handler({ message: 'event response' }, mockContext);
 
-    expect(result).toContain('This is a child session');
-    expect(result).toContain('Messages from user in this session: 0');
-    expect(result).toContain('eventTrigger');
+    expect(result).toContain('ERROR');
+    expect(result).toContain('not available');
+    expect(result).toContain('0 user messages');
+    expect(result).toContain('sendMessageToAgent');
+    expect(result).toContain('Do NOT call confirmSendToUser');
     expect(mockSendMessageToSlack).not.toHaveBeenCalled();
   });
 
-  test('skips toolUse/toolResult/assistant/errorFeedback to find triggering message', async () => {
+  test('skips toolUse/toolResult/assistant/errorFeedback to find triggering message (no user messages = error)', async () => {
     mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
     mockGetConversationHistory.mockResolvedValue({
       items: [
@@ -135,12 +139,39 @@ describe('sendMessageToUser child session confirmation', () => {
 
     const result = await reportProgressTool.handler({ message: 'tool done' }, mockContext);
 
-    expect(result).toContain('This is a child session');
+    expect(result).toContain('ERROR');
+    expect(result).toContain('not available');
+    expect(result).toContain('0 user messages');
+    expect(mockSendMessageToSlack).not.toHaveBeenCalled();
+  });
+
+  test('skips toolUse/toolResult/assistant/errorFeedback to find triggering message (has user messages = warning)', async () => {
+    mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
+    mockGetConversationHistory.mockResolvedValue({
+      items: [
+        { messageType: 'userMessage' },
+        { messageType: 'assistant' },
+        { messageType: 'agentMessage', senderAgentName: 'Parent' },
+        { messageType: 'assistant' },
+        { messageType: 'toolUse' },
+        { messageType: 'toolResult' },
+        { messageType: 'assistant' },
+        { messageType: 'toolUse' },
+        { messageType: 'toolResult' },
+        { messageType: 'errorFeedback' },
+        { messageType: 'toolUse' },
+      ],
+    });
+
+    const result = await reportProgressTool.handler({ message: 'tool done' }, mockContext);
+
+    expect(result).toContain('WARNING');
+    expect(result).toContain('99%');
     expect(result).toContain('agentMessage (Parent)');
     expect(mockSendMessageToSlack).not.toHaveBeenCalled();
   });
 
-  test('child session with empty items returns confirmation prompt', async () => {
+  test('child session with empty items returns hard error (no user messages)', async () => {
     mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
     mockGetConversationHistory.mockResolvedValue({
       items: [],
@@ -148,9 +179,10 @@ describe('sendMessageToUser child session confirmation', () => {
 
     const result = await reportProgressTool.handler({ message: 'empty history' }, mockContext);
 
-    expect(result).toContain('This is a child session');
-    expect(result).toContain('Messages from user in this session: 0');
-    expect(result).toContain('unknown');
+    expect(result).toContain('ERROR');
+    expect(result).toContain('not available');
+    expect(result).toContain('0 user messages');
+    expect(result).toContain('Do NOT call confirmSendToUser');
     expect(mockSendMessageToSlack).not.toHaveBeenCalled();
   });
 
@@ -170,10 +202,13 @@ describe('confirmSendToUser', () => {
   });
 
   test('sends the blocked message when called', async () => {
-    // First block a message
+    // First block a message (Case 2: has user messages but non-user trigger)
     mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
     mockGetConversationHistory.mockResolvedValue({
-      items: [{ messageType: 'agentMessage', senderAgentName: 'PM' }],
+      items: [
+        { messageType: 'userMessage' },
+        { messageType: 'agentMessage', senderAgentName: 'PM' },
+      ],
     });
 
     await reportProgressTool.handler({ message: 'pending message content' }, mockContext);
@@ -194,10 +229,13 @@ describe('confirmSendToUser', () => {
   });
 
   test('pending message is cleaned up after confirm', async () => {
-    // Block a message
+    // Block a message (Case 2: has user messages but non-user trigger)
     mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
     mockGetConversationHistory.mockResolvedValue({
-      items: [{ messageType: 'agentMessage', senderAgentName: 'PM' }],
+      items: [
+        { messageType: 'userMessage' },
+        { messageType: 'agentMessage', senderAgentName: 'PM' },
+      ],
     });
 
     await reportProgressTool.handler({ message: 'once only' }, mockContext);
@@ -206,5 +244,20 @@ describe('confirmSendToUser', () => {
     // Second confirm should have no pending message
     const result = await confirmSendToUserTool.handler({}, mockContext);
     expect(result).toBe('No pending message to confirm. Use sendMessageToUser first.');
+  });
+
+  test('confirmSendToUser fails when message was blocked by Case 1 (no user messages)', async () => {
+    // Case 1: no user messages - message is NOT saved as pending
+    mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
+    mockGetConversationHistory.mockResolvedValue({
+      items: [{ messageType: 'agentMessage', senderAgentName: 'PM' }],
+    });
+
+    await reportProgressTool.handler({ message: 'should not be saved' }, mockContext);
+
+    // confirmSendToUser should have no pending message
+    const result = await confirmSendToUserTool.handler({}, mockContext);
+    expect(result).toBe('No pending message to confirm. Use sendMessageToUser first.');
+    expect(mockSendMessageToSlack).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent-core/src/tools/report-progress/index.test.ts
+++ b/packages/agent-core/src/tools/report-progress/index.test.ts
@@ -60,12 +60,14 @@ describe('sendMessageToUser child session confirmation', () => {
     expect(mockSendMessageToSlack).toHaveBeenCalledWith('hello user');
   });
 
-  test('child session with last message as userMessage sends directly', async () => {
+  test('child session with triggering message as userMessage sends directly', async () => {
     mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
     mockGetConversationHistory.mockResolvedValue({
       items: [
         { messageType: 'agentMessage', senderAgentName: 'PM' },
         { messageType: 'userMessage' },
+        { messageType: 'assistant' },
+        { messageType: 'toolUse' },
       ],
     });
 
@@ -75,12 +77,16 @@ describe('sendMessageToUser child session confirmation', () => {
     expect(mockSendMessageToSlack).toHaveBeenCalledWith('reply to user');
   });
 
-  test('child session with last message as agentMessage returns confirmation prompt', async () => {
+  test('child session with triggering message as agentMessage returns confirmation prompt', async () => {
     mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
     mockGetConversationHistory.mockResolvedValue({
       items: [
         { messageType: 'userMessage' },
         { messageType: 'agentMessage', senderAgentName: 'PM Agent' },
+        { messageType: 'assistant' },
+        { messageType: 'toolUse' },
+        { messageType: 'toolResult' },
+        { messageType: 'toolUse' },
       ],
     });
 
@@ -93,11 +99,13 @@ describe('sendMessageToUser child session confirmation', () => {
     expect(mockSendMessageToSlack).not.toHaveBeenCalled();
   });
 
-  test('child session with last message as eventTrigger returns confirmation prompt', async () => {
+  test('child session with triggering message as eventTrigger returns confirmation prompt', async () => {
     mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
     mockGetConversationHistory.mockResolvedValue({
       items: [
         { messageType: 'eventTrigger' },
+        { messageType: 'assistant' },
+        { messageType: 'toolUse' },
       ],
     });
 
@@ -109,19 +117,40 @@ describe('sendMessageToUser child session confirmation', () => {
     expect(mockSendMessageToSlack).not.toHaveBeenCalled();
   });
 
-  test('child session with last message as toolResult (from agent loop) returns confirmation prompt', async () => {
+  test('skips toolUse/toolResult/assistant/errorFeedback to find triggering message', async () => {
     mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
     mockGetConversationHistory.mockResolvedValue({
       items: [
         { messageType: 'agentMessage', senderAgentName: 'Parent' },
+        { messageType: 'assistant' },
         { messageType: 'toolUse' },
         { messageType: 'toolResult' },
+        { messageType: 'assistant' },
+        { messageType: 'toolUse' },
+        { messageType: 'toolResult' },
+        { messageType: 'errorFeedback' },
+        { messageType: 'toolUse' },
       ],
     });
 
     const result = await reportProgressTool.handler({ message: 'tool done' }, mockContext);
 
     expect(result).toContain('This is a child session');
+    expect(result).toContain('agentMessage (Parent)');
+    expect(mockSendMessageToSlack).not.toHaveBeenCalled();
+  });
+
+  test('child session with empty items returns confirmation prompt', async () => {
+    mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
+    mockGetConversationHistory.mockResolvedValue({
+      items: [],
+    });
+
+    const result = await reportProgressTool.handler({ message: 'empty history' }, mockContext);
+
+    expect(result).toContain('This is a child session');
+    expect(result).toContain('Messages from user in this session: 0');
+    expect(result).toContain('unknown');
     expect(mockSendMessageToSlack).not.toHaveBeenCalled();
   });
 

--- a/packages/agent-core/src/tools/report-progress/index.test.ts
+++ b/packages/agent-core/src/tools/report-progress/index.test.ts
@@ -104,11 +104,7 @@ describe('sendMessageToUser child session confirmation', () => {
   test('child session with triggering message as eventTrigger and no user messages returns hard error', async () => {
     mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
     mockGetConversationHistory.mockResolvedValue({
-      items: [
-        { messageType: 'eventTrigger' },
-        { messageType: 'assistant' },
-        { messageType: 'toolUse' },
-      ],
+      items: [{ messageType: 'eventTrigger' }, { messageType: 'assistant' }, { messageType: 'toolUse' }],
     });
 
     const result = await reportProgressTool.handler({ message: 'event response' }, mockContext);
@@ -205,10 +201,7 @@ describe('confirmSendToUser', () => {
     // First block a message (Case 2: has user messages but non-user trigger)
     mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
     mockGetConversationHistory.mockResolvedValue({
-      items: [
-        { messageType: 'userMessage' },
-        { messageType: 'agentMessage', senderAgentName: 'PM' },
-      ],
+      items: [{ messageType: 'userMessage' }, { messageType: 'agentMessage', senderAgentName: 'PM' }],
     });
 
     await reportProgressTool.handler({ message: 'pending message content' }, mockContext);
@@ -232,10 +225,7 @@ describe('confirmSendToUser', () => {
     // Block a message (Case 2: has user messages but non-user trigger)
     mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
     mockGetConversationHistory.mockResolvedValue({
-      items: [
-        { messageType: 'userMessage' },
-        { messageType: 'agentMessage', senderAgentName: 'PM' },
-      ],
+      items: [{ messageType: 'userMessage' }, { messageType: 'agentMessage', senderAgentName: 'PM' }],
     });
 
     await reportProgressTool.handler({ message: 'once only' }, mockContext);

--- a/packages/agent-core/src/tools/report-progress/index.test.ts
+++ b/packages/agent-core/src/tools/report-progress/index.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { globalPreferencesSchema } from '../../schema';
+
+const mockGetSession = vi.fn();
+const mockGetConversationHistory = vi.fn();
+const mockSendMessageToSlack = vi.fn();
+const mockUpdateSessionLastMessage = vi.fn();
+const mockSendWebappEvent = vi.fn();
+const mockSendPushNotificationToUser = vi.fn();
+const mockIncrementUnread = vi.fn();
+
+vi.mock('../../lib/sessions', () => ({
+  getSession: (...args: any[]) => mockGetSession(...args),
+  updateSessionLastMessage: (...args: any[]) => mockUpdateSessionLastMessage(...args),
+}));
+
+vi.mock('../../lib/messages', () => ({
+  getConversationHistory: (...args: any[]) => mockGetConversationHistory(...args),
+}));
+
+vi.mock('../../lib/slack', () => ({
+  sendMessageToSlack: (...args: any[]) => mockSendMessageToSlack(...args),
+}));
+
+vi.mock('../../lib/events', () => ({
+  sendWebappEvent: (...args: any[]) => mockSendWebappEvent(...args),
+}));
+
+vi.mock('../../lib/push-notification', () => ({
+  sendPushNotificationToUser: (...args: any[]) => mockSendPushNotificationToUser(...args),
+}));
+
+vi.mock('../../lib/unread', () => ({
+  incrementUnread: (...args: any[]) => mockIncrementUnread(...args),
+}));
+
+import { reportProgressTool } from './index';
+import { confirmSendToUserTool, loadAndDeletePendingUserMessage } from '../confirm-send-to-user';
+
+const mockContext = {
+  workerId: 'test-worker-123',
+  toolUseId: 'test-tool-use',
+  globalPreferences: globalPreferencesSchema.parse({
+    PK: 'global-config',
+    SK: 'general',
+  }),
+};
+
+describe('sendMessageToUser child session confirmation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('parent session sends message directly without confirmation', async () => {
+    mockGetSession.mockResolvedValue({ parentSessionId: undefined });
+
+    const result = await reportProgressTool.handler({ message: 'hello user' }, mockContext);
+
+    expect(result).toBe('Successfully sent a message.');
+    expect(mockSendMessageToSlack).toHaveBeenCalledWith('hello user');
+  });
+
+  test('child session with last message as userMessage sends directly', async () => {
+    mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
+    mockGetConversationHistory.mockResolvedValue({
+      items: [
+        { messageType: 'agentMessage', senderAgentName: 'PM' },
+        { messageType: 'userMessage' },
+      ],
+    });
+
+    const result = await reportProgressTool.handler({ message: 'reply to user' }, mockContext);
+
+    expect(result).toBe('Successfully sent a message.');
+    expect(mockSendMessageToSlack).toHaveBeenCalledWith('reply to user');
+  });
+
+  test('child session with last message as agentMessage returns confirmation prompt', async () => {
+    mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
+    mockGetConversationHistory.mockResolvedValue({
+      items: [
+        { messageType: 'userMessage' },
+        { messageType: 'agentMessage', senderAgentName: 'PM Agent' },
+      ],
+    });
+
+    const result = await reportProgressTool.handler({ message: 'blocked message' }, mockContext);
+
+    expect(result).toContain('This is a child session');
+    expect(result).toContain('Messages from user in this session: 1');
+    expect(result).toContain('agentMessage (PM Agent)');
+    expect(result).toContain('confirmSendToUser');
+    expect(mockSendMessageToSlack).not.toHaveBeenCalled();
+  });
+
+  test('child session with last message as eventTrigger returns confirmation prompt', async () => {
+    mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
+    mockGetConversationHistory.mockResolvedValue({
+      items: [
+        { messageType: 'eventTrigger' },
+      ],
+    });
+
+    const result = await reportProgressTool.handler({ message: 'event response' }, mockContext);
+
+    expect(result).toContain('This is a child session');
+    expect(result).toContain('Messages from user in this session: 0');
+    expect(result).toContain('eventTrigger');
+    expect(mockSendMessageToSlack).not.toHaveBeenCalled();
+  });
+
+  test('child session with last message as toolResult (from agent loop) returns confirmation prompt', async () => {
+    mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
+    mockGetConversationHistory.mockResolvedValue({
+      items: [
+        { messageType: 'agentMessage', senderAgentName: 'Parent' },
+        { messageType: 'toolUse' },
+        { messageType: 'toolResult' },
+      ],
+    });
+
+    const result = await reportProgressTool.handler({ message: 'tool done' }, mockContext);
+
+    expect(result).toContain('This is a child session');
+    expect(mockSendMessageToSlack).not.toHaveBeenCalled();
+  });
+
+  test('session without parentSessionId (null) sends directly', async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const result = await reportProgressTool.handler({ message: 'no session' }, mockContext);
+
+    expect(result).toBe('Successfully sent a message.');
+    expect(mockSendMessageToSlack).toHaveBeenCalled();
+  });
+});
+
+describe('confirmSendToUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('sends the blocked message when called', async () => {
+    // First block a message
+    mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
+    mockGetConversationHistory.mockResolvedValue({
+      items: [{ messageType: 'agentMessage', senderAgentName: 'PM' }],
+    });
+
+    await reportProgressTool.handler({ message: 'pending message content' }, mockContext);
+    expect(mockSendMessageToSlack).not.toHaveBeenCalled();
+
+    // Now confirm
+    const result = await confirmSendToUserTool.handler({}, mockContext);
+
+    expect(result).toBe('Successfully sent the message to the user.');
+    expect(mockSendMessageToSlack).toHaveBeenCalledWith('pending message content');
+  });
+
+  test('returns error when no pending message', async () => {
+    const result = await confirmSendToUserTool.handler({}, mockContext);
+
+    expect(result).toBe('No pending message to confirm. Use sendMessageToUser first.');
+    expect(mockSendMessageToSlack).not.toHaveBeenCalled();
+  });
+
+  test('pending message is cleaned up after confirm', async () => {
+    // Block a message
+    mockGetSession.mockResolvedValue({ parentSessionId: 'parent-123' });
+    mockGetConversationHistory.mockResolvedValue({
+      items: [{ messageType: 'agentMessage', senderAgentName: 'PM' }],
+    });
+
+    await reportProgressTool.handler({ message: 'once only' }, mockContext);
+    await confirmSendToUserTool.handler({}, mockContext);
+
+    // Second confirm should have no pending message
+    const result = await confirmSendToUserTool.handler({}, mockContext);
+    expect(result).toBe('No pending message to confirm. Use sendMessageToUser first.');
+  });
+});

--- a/packages/agent-core/src/tools/report-progress/index.ts
+++ b/packages/agent-core/src/tools/report-progress/index.ts
@@ -5,6 +5,8 @@ import { sendPushNotificationToUser } from '../../lib/push-notification';
 import { incrementUnread } from '../../lib/unread';
 import { getSession, updateSessionLastMessage } from '../../lib/sessions';
 import { sendWebappEvent } from '../../lib/events';
+import { getConversationHistory } from '../../lib/messages';
+import { savePendingUserMessage } from '../confirm-send-to-user';
 
 const inputSchema = z.object({
   message: z.string().describe('The message you want to send to the user.'),
@@ -12,39 +14,67 @@ const inputSchema = z.object({
 
 const name = 'sendMessageToUser';
 
+export const sendMessageToUser = async (workerId: string, message: string) => {
+  await sendMessageToSlack(message);
+
+  const lastMessagePreview = message.slice(0, 500);
+  await updateSessionLastMessage(workerId, lastMessagePreview);
+  await sendWebappEvent(workerId, {
+    type: 'lastMessageUpdate',
+    lastMessage: lastMessagePreview,
+    lastMessageAt: Date.now(),
+  });
+
+  // Send push notification
+  try {
+    const session = await getSession(workerId);
+    if (session?.initiator?.startsWith('webapp#')) {
+      const userId = session.initiator.replace('webapp#', '');
+      const title = session.title || 'Agent Message';
+
+      await incrementUnread(userId, workerId);
+
+      await sendPushNotificationToUser(userId, {
+        title,
+        body: message.slice(0, 200),
+        url: `/sessions/${workerId}`,
+        workerId,
+      });
+    }
+  } catch (e) {
+    console.error('[push] Failed to send push from sendMessageToUser:', e);
+  }
+};
+
 export const reportProgressTool: ToolDefinition<z.infer<typeof inputSchema>> = {
   name,
   handler: async (input: z.infer<typeof inputSchema>, context) => {
-    await sendMessageToSlack(input.message);
+    const session = await getSession(context.workerId);
 
-    const lastMessagePreview = input.message.slice(0, 500);
-    await updateSessionLastMessage(context.workerId, lastMessagePreview);
-    await sendWebappEvent(context.workerId, {
-      type: 'lastMessageUpdate',
-      lastMessage: lastMessagePreview,
-      lastMessageAt: Date.now(),
-    });
+    // Child session confirmation check
+    if (session?.parentSessionId) {
+      const { items } = await getConversationHistory(context.workerId);
+      const lastItem = items.at(-1);
+      const lastMessageType = lastItem?.messageType ?? 'unknown';
 
-    // Send push notification
-    try {
-      const session = await getSession(context.workerId);
-      if (session?.initiator?.startsWith('webapp#')) {
-        const userId = session.initiator.replace('webapp#', '');
-        const title = session.title || 'Agent Message';
+      if (lastMessageType !== 'userMessage') {
+        const userMessageCount = items.filter((i) => i.messageType === 'userMessage').length;
+        const senderInfo = lastItem?.senderAgentName ?? lastItem?.senderSessionId ?? 'system';
 
-        await incrementUnread(userId, context.workerId);
+        savePendingUserMessage(context.workerId, input.message);
 
-        await sendPushNotificationToUser(userId, {
-          title,
-          body: input.message.slice(0, 200),
-          url: `/sessions/${context.workerId}`,
-          workerId: context.workerId,
-        });
+        return [
+          `This is a child session. sendMessageToUser will notify the user directly.`,
+          `- Messages from user in this session: ${userMessageCount}`,
+          `- Last message is from: ${lastMessageType} (${senderInfo})`,
+          ``,
+          `If you intended to report to the parent, use sendMessageToAgent instead.`,
+          `If you still want to send directly to the user, call confirmSendToUser to confirm.`,
+        ].join('\n');
       }
-    } catch (e) {
-      console.error('[push] Failed to send push from sendMessageToUser:', e);
     }
 
+    await sendMessageToUser(context.workerId, input.message);
     return 'Successfully sent a message.';
   },
   schema: inputSchema,

--- a/packages/agent-core/src/tools/report-progress/index.ts
+++ b/packages/agent-core/src/tools/report-progress/index.ts
@@ -65,15 +65,33 @@ export const reportProgressTool: ToolDefinition<z.infer<typeof inputSchema>> = {
         const userMessageCount = items.filter((i) => i.messageType === 'userMessage').length;
         const senderInfo = triggeringItem?.senderAgentName ?? triggeringItem?.senderSessionId ?? 'system';
 
+        // Case 1: No user messages at all - the user never interacted with this session directly.
+        // Block completely without allowing confirmSendToUser.
+        if (userMessageCount === 0) {
+          return [
+            `ERROR: sendMessageToUser is not available in this child session.`,
+            `The user has never sent a message to this session directly (0 user messages), which means they do not expect to receive messages from here.`,
+            ``,
+            `You MUST use sendMessageToAgent to report to your parent session instead.`,
+            `Do NOT call confirmSendToUser — it will not work for this case.`,
+          ].join('\n');
+        }
+
+        // Case 2: User has interacted before, but the most recent triggering message is not from the user.
+        // Allow with strong warning + confirmSendToUser.
         savePendingUserMessage(context.workerId, input.message);
 
         return [
-          `This is a child session. sendMessageToUser will notify the user directly.`,
+          `WARNING: You are almost certainly making a mistake. There is a 99% chance you should NOT send this message directly to the user.`,
+          ``,
+          `This is a child session and the last triggering message is NOT from the user:`,
           `- Messages from user in this session: ${userMessageCount}`,
           `- Last message is from: ${triggeringMessageType} (${senderInfo})`,
           ``,
-          `If you intended to report to the parent, use sendMessageToAgent instead.`,
-          `If you still want to send directly to the user, call confirmSendToUser to confirm.`,
+          `The only scenario where sending directly to the user is appropriate is when the user previously asked you to investigate something directly in this session and you are reporting back after a long delay.`,
+          ``,
+          `In almost all cases, you should use sendMessageToAgent to report to your parent session instead.`,
+          `If you are ABSOLUTELY CERTAIN this is one of the rare exceptions, call confirmSendToUser to proceed.`,
         ].join('\n');
       }
     }

--- a/packages/agent-core/src/tools/report-progress/index.ts
+++ b/packages/agent-core/src/tools/report-progress/index.ts
@@ -54,19 +54,23 @@ export const reportProgressTool: ToolDefinition<z.infer<typeof inputSchema>> = {
     // Child session confirmation check
     if (session?.parentSessionId) {
       const { items } = await getConversationHistory(context.workerId);
-      const lastItem = items.at(-1);
-      const lastMessageType = lastItem?.messageType ?? 'unknown';
+      // Skip toolUse/toolResult/assistant/errorFeedback to find the actual triggering message.
+      // The last item is typically toolUse (saved before handler runs), so we need to look past it.
+      const triggeringItem = items.findLast(
+        (i) => !['toolUse', 'toolResult', 'assistant', 'errorFeedback'].includes(i.messageType)
+      );
+      const triggeringMessageType = triggeringItem?.messageType ?? 'unknown';
 
-      if (lastMessageType !== 'userMessage') {
+      if (triggeringMessageType !== 'userMessage') {
         const userMessageCount = items.filter((i) => i.messageType === 'userMessage').length;
-        const senderInfo = lastItem?.senderAgentName ?? lastItem?.senderSessionId ?? 'system';
+        const senderInfo = triggeringItem?.senderAgentName ?? triggeringItem?.senderSessionId ?? 'system';
 
         savePendingUserMessage(context.workerId, input.message);
 
         return [
           `This is a child session. sendMessageToUser will notify the user directly.`,
           `- Messages from user in this session: ${userMessageCount}`,
-          `- Last message is from: ${lastMessageType} (${senderInfo})`,
+          `- Last message is from: ${triggeringMessageType} (${senderInfo})`,
           ``,
           `If you intended to report to the parent, use sendMessageToAgent instead.`,
           `If you still want to send directly to the user, call confirmSendToUser to confirm.`,

--- a/packages/agent-core/src/tools/send-to-agent/index.ts
+++ b/packages/agent-core/src/tools/send-to-agent/index.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+import { ToolDefinition, zodToJsonSchemaBody } from '../../private/common/lib';
+import { sendAgentMessage } from '../../lib/agent-messaging';
+
+const inputSchema = z.object({
+  targetSessionIds: z.array(z.string()).min(1).describe('One or more session IDs to send the message to.'),
+  message: z.string().min(1).describe('The message to send to the target agent(s).'),
+});
+
+const name = 'sendMessageToAgent';
+
+export const sendToAgentTool: ToolDefinition<z.infer<typeof inputSchema>> = {
+  name,
+  handler: async (input: z.infer<typeof inputSchema>, context) => {
+    const result = await sendAgentMessage({
+      senderWorkerId: context.workerId,
+      targetSessionIds: input.targetSessionIds,
+      message: input.message,
+    });
+
+    const lines: string[] = [];
+    if (result.sent.length > 0) {
+      lines.push(`Successfully sent message to: ${result.sent.join(', ')}`);
+    }
+    for (const f of result.failed) {
+      lines.push(`Failed to send to ${f.sessionId}: ${f.reason}`);
+    }
+    return lines.join('\n') || 'No messages sent.';
+  },
+  schema: inputSchema,
+  toolSpec: async () => ({
+    name,
+    description: `Send a message to one or more agent sessions. Use this for agent-to-agent communication.
+The target agent(s) will receive the message and be woken up to process it.
+The user will NOT be notified directly — use sendMessageToUser for user-facing messages.
+
+You can find session IDs of your parent/siblings from the session hierarchy information in your system prompt,
+or from the response of createNewSession when you create child sessions.`,
+    inputSchema: {
+      json: zodToJsonSchemaBody(inputSchema),
+    },
+  }),
+};

--- a/packages/agent-core/src/tools/session-title/index.ts
+++ b/packages/agent-core/src/tools/session-title/index.ts
@@ -29,12 +29,12 @@ export const updateSessionTitleTool: ToolDefinition<z.infer<typeof inputSchema>>
 
 ## When to use:
 - At the end of your FIRST turn, after understanding what the user wants
-- When the conversation topic significantly changes
+- Proactively whenever the conversation topic evolves or shifts to a different focus. Don't leave a stale title.
 - When the user explicitly asks to rename the session
 
 ## Guidelines:
 - Keep titles concise (under 30 characters preferred)
-- Make titles descriptive of the main topic or task
+- Make titles descriptive of the current main topic or task
 - Use the same language the user is using`,
     inputSchema: {
       json: zodToJsonSchemaBody(inputSchema),

--- a/packages/webapp/src/app/sessions/(root)/components/SessionsList.tsx
+++ b/packages/webapp/src/app/sessions/(root)/components/SessionsList.tsx
@@ -70,7 +70,6 @@ export default function SessionsList({ initialSessions, currentUserId, unreadMap
   const [selectMode, setSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [showBatchDeleteDialog, setShowBatchDeleteDialog] = useState(false);
-
   const { execute: executeDeleteSession } = useAction(deleteSessionAction, {
     onSuccess: () => {
       toast.success(t('deleteSessionSuccess'));
@@ -232,8 +231,23 @@ export default function SessionsList({ initialSessions, currentUserId, unreadMap
     setSelectedIds(new Set());
   }, []);
 
+  // Build a map of parentSessionId -> child sessions
+  const childrenMap = useMemo(() => {
+    const map: Record<string, SessionItem[]> = {};
+    for (const session of sessions) {
+      if (session.parentSessionId) {
+        if (!map[session.parentSessionId]) {
+          map[session.parentSessionId] = [];
+        }
+        map[session.parentSessionId].push(session);
+      }
+    }
+    return map;
+  }, [sessions]);
+
   const sortedSessions = useMemo(() => {
-    let filtered = sessions;
+    // Only show root sessions (no parentSessionId) at the top level
+    let filtered = sessions.filter((s) => !s.parentSessionId);
     if (hideCompleted) {
       filtered = filtered.filter((s) => s.agentStatus !== 'completed');
     }
@@ -343,6 +357,7 @@ export default function SessionsList({ initialSessions, currentUserId, unreadMap
           const status = getUnifiedStatus(session.agentStatus, session.instanceStatus);
           const isOtherUserSession = session.initiator && session.initiator !== `webapp#${currentUserId}`;
           const isSelected = selectedIds.has(session.workerId);
+          const hasChildren = (childrenMap[session.workerId] ?? []).length > 0;
           return (
             <div key={session.workerId} className="relative">
               {selectMode ? (
@@ -485,7 +500,7 @@ export default function SessionsList({ initialSessions, currentUserId, unreadMap
                         className="cursor-pointer"
                       >
                         <Trash2 className="w-4 h-4 mr-2" />
-                        {t('deleteSession')}
+                        {hasChildren ? t('deleteGroup') : t('deleteSession')}
                       </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>
@@ -501,7 +516,11 @@ export default function SessionsList({ initialSessions, currentUserId, unreadMap
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>{t('deleteSession')}</AlertDialogTitle>
-            <AlertDialogDescription>{t('deleteSessionConfirm')}</AlertDialogDescription>
+            <AlertDialogDescription>
+              {deleteTargetId && (childrenMap[deleteTargetId]?.length ?? 0) > 0
+                ? t('deleteGroupConfirm', { count: childrenMap[deleteTargetId].length })
+                : t('deleteSessionConfirm')}
+            </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>{t('cancel')}</AlertDialogCancel>

--- a/packages/webapp/src/app/sessions/(root)/page.tsx
+++ b/packages/webapp/src/app/sessions/(root)/page.tsx
@@ -1,5 +1,5 @@
 import HeaderWithPreferences from '@/components/HeaderWithPreferences';
-import { getSessions, getUnreadMap } from '@remote-swe-agents/agent-core/lib';
+import { getAllSessionsIncludingChildren, getUnreadMap } from '@remote-swe-agents/agent-core/lib';
 import { RefreshOnFocus } from '@/components/RefreshOnFocus';
 import SessionsList from './components/SessionsList';
 import { getSession } from '@/lib/auth';
@@ -8,7 +8,8 @@ export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
 export default async function SessionsPage() {
-  const sessions = await getSessions(100);
+  const allSessions = await getAllSessionsIncludingChildren();
+  const visibleSessions = allSessions.filter((s) => !s.isHidden);
   const { userId } = await getSession();
   const unreadMap = await getUnreadMap(userId);
 
@@ -19,7 +20,7 @@ export default async function SessionsPage() {
 
       <main className="flex-grow pt-20">
         <div className="max-w-6xl mx-auto px-4 pb-8">
-          <SessionsList initialSessions={sessions} currentUserId={userId} unreadMap={unreadMap} />
+          <SessionsList initialSessions={visibleSessions} currentUserId={userId} unreadMap={unreadMap} />
         </div>
       </main>
     </div>

--- a/packages/webapp/src/app/sessions/[workerId]/component/AgentMessageRenderer.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/AgentMessageRenderer.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+import { ArrowRight, ArrowLeft, ChevronRight, ChevronDown, Bot } from 'lucide-react';
+import { MessageView } from './MessageList';
+import { MarkdownRenderer } from './MarkdownRenderer';
+
+type AgentMessageRendererProps = {
+  message: MessageView;
+  /** The agent name of the currently open chat session */
+  agentName?: string;
+};
+
+/**
+ * Renders an agent-to-agent message with compact communication log style.
+ *
+ * Arrow direction indicates send/receive relative to the current session's agent:
+ * - Current agent is target (receiving): CurrentAgent ← SenderAgent
+ * - Current agent is sender (sending): CurrentAgent → TargetAgent
+ * - Neither matches (e.g. parent watching): SenderAgent → TargetAgent
+ */
+export const AgentMessageRenderer = ({ message, agentName }: AgentMessageRendererProps) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const isAck = message.isAcknowledge;
+
+  const isCurrentTarget = agentName && message.targetAgentName === agentName;
+  const isCurrentSender = agentName && message.senderAgentName === agentName;
+
+  let leftName: string;
+  let rightName: string | undefined;
+  let arrowDirection: '←' | '→';
+
+  if (isCurrentTarget) {
+    leftName = agentName;
+    rightName = message.senderAgentName || 'Agent';
+    arrowDirection = '←';
+  } else if (isCurrentSender) {
+    leftName = agentName;
+    rightName = message.targetAgentName || 'Agent';
+    arrowDirection = '→';
+  } else {
+    leftName = message.senderAgentName || 'Agent';
+    rightName = message.targetAgentName;
+    arrowDirection = '→';
+  }
+
+  const ArrowIcon = arrowDirection === '←' ? ArrowLeft : ArrowRight;
+
+  return (
+    <div className="rounded-md min-w-0 w-full overflow-hidden">
+      <div className="flex items-start gap-2 min-w-0">
+        <button onClick={() => setIsExpanded(!isExpanded)} className="flex-shrink-0 mt-0.5 cursor-pointer">
+          {isExpanded ? (
+            <ChevronDown className="w-4 h-4 text-gray-400" />
+          ) : (
+            <ChevronRight className="w-4 h-4 text-gray-400" />
+          )}
+        </button>
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={() => setIsExpanded(!isExpanded)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              setIsExpanded(!isExpanded);
+            }
+          }}
+          className="flex-1 flex items-center text-left text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 cursor-pointer min-w-0 gap-2"
+        >
+          <Bot className="w-4 h-4 flex-shrink-0 text-blue-500" />
+          <span className="font-medium text-sm truncate">{leftName}</span>
+          {rightName ? (
+            <>
+              <ArrowIcon className="w-3.5 h-3.5 flex-shrink-0" />
+              <span className="font-medium text-sm truncate">{rightName}</span>
+              {isAck && <span className="text-xs text-green-600 dark:text-green-400 flex-shrink-0">(ack)</span>}
+            </>
+          ) : (
+            <span className="text-sm text-gray-500 truncate">
+              {message.content.length > 60 ? message.content.slice(0, 60) + '...' : message.content}
+            </span>
+          )}
+        </div>
+      </div>
+      {isExpanded && (
+        <div className="ml-6 mt-2 p-3 rounded-md bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 overflow-x-auto max-w-full">
+          <div className="text-sm text-gray-700 dark:text-gray-300 [&_pre]:overflow-x-auto [&_pre]:max-w-full [&_code]:break-all">
+            <MarkdownRenderer content={message.content} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageGroup.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageGroup.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Bot, User, Brain } from 'lucide-react';
+import Link from 'next/link';
+import { Bot, User, Brain, GitBranch } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { MessageView, MessageGroup } from './MessageList';
@@ -24,6 +25,9 @@ export const MessageGroupComponent = React.memo(function MessageGroupComponent({
   const localeForDate = locale === 'ja' ? 'ja-JP' : 'en-US';
   const firstMessage = group.messages[0];
   const firstMessageDate = new Date(firstMessage.timestamp);
+  const isChildSessionMessage = !!firstMessage.agentName;
+  const childSessionId = firstMessage.childSessionId;
+  const isAgentMessage = firstMessage.type === 'agentMessage';
 
   const isSameTime = (timestamp1: Date, timestamp2: Date): boolean => {
     return timestamp1.getHours() === timestamp2.getHours() && timestamp1.getMinutes() === timestamp2.getMinutes();
@@ -42,53 +46,82 @@ export const MessageGroupComponent = React.memo(function MessageGroupComponent({
     return 'text-gray-800 dark:text-gray-100';
   };
 
-  return (
-    <div className="mb-3">
-      <div className="flex items-center gap-3 mb-2">
-        <div className="flex-shrink-0">
-          {group.role === 'assistant' && agentIconUrl ? (
-            /* eslint-disable-next-line @next/next/no-img-element */
-            <img src={agentIconUrl} alt="Agent" className="w-8 h-8 rounded-full object-cover" />
-          ) : (
-            <div
-              className={`w-8 h-8 rounded-full flex items-center justify-center ${
-                group.role === 'assistant' ? 'bg-blue-600' : 'bg-gray-600'
-              }`}
-            >
-              {group.role === 'assistant' ? (
-                <Bot className="w-4 h-4 text-white" />
-              ) : (
-                <User className="w-4 h-4 text-white" />
-              )}
-            </div>
-          )}
+  const displayName = isChildSessionMessage
+    ? firstMessage.agentName
+    : group.role === 'assistant'
+      ? agentName || 'Assistant'
+      : 'User';
+
+  // Determine icon and styling for agent messages
+  const getIcon = () => {
+    if (isChildSessionMessage) {
+      return (
+        <div className="w-8 h-8 rounded-full flex items-center justify-center bg-blue-500">
+          <GitBranch className="w-4 h-4 text-white" />
         </div>
-        <div className="font-semibold text-gray-900 dark:text-white">
-          {group.role === 'assistant' ? agentName || 'Assistant' : 'User'}
-        </div>
-        <div className="text-sm text-gray-500 dark:text-gray-400 flex items-center">
-          {formatDateTime(firstMessageDate, localeForDate)}
-          {group.role === 'assistant' && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="ml-2">
-                  <Brain className={`w-4 h-4 ${getBrainColor(thinkingBudget)}`} />
-                </span>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>
-                  {group.messages.find((msg) => msg.thinkingBudget)
-                    ? `${t('thinkingBudget')}: ${thinkingBudget.toLocaleString()}`
-                    : `${t('thinkingBudget')}: ${t('defaultThinkingBudget')}`}
-                </p>
-                {!group.messages.find((msg) => msg.thinkingBudget) && (
-                  <p className="text-xs mt-1">{t('ultrathinkInstruction')}</p>
-                )}
-              </TooltipContent>
-            </Tooltip>
-          )}
-        </div>
+      );
+    }
+    if (group.role === 'assistant' && agentIconUrl) {
+      /* eslint-disable-next-line @next/next/no-img-element */
+      return <img src={agentIconUrl} alt="Agent" className="w-8 h-8 rounded-full object-cover" />;
+    }
+    return (
+      <div
+        className={`w-8 h-8 rounded-full flex items-center justify-center ${
+          group.role === 'assistant' ? 'bg-blue-600' : 'bg-gray-600'
+        }`}
+      >
+        {group.role === 'assistant' ? <Bot className="w-4 h-4 text-white" /> : <User className="w-4 h-4 text-white" />}
       </div>
+    );
+  };
+
+  // For agent messages, use a more compact style (both parent and child views)
+  const containerClass = isAgentMessage
+    ? 'mb-2'
+    : `mb-3 ${isChildSessionMessage ? 'ml-4 border-l-2 border-blue-200 dark:border-blue-800 pl-3' : ''}`;
+
+  return (
+    <div className={containerClass}>
+      {/* Hide the full header for agent messages (the renderer handles display) */}
+      {!isAgentMessage && (
+        <div className="flex items-center gap-3 mb-2">
+          <div className="flex-shrink-0">{getIcon()}</div>
+          <div className="font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+            {displayName}
+            {childSessionId && (
+              <Link
+                href={`/sessions/${childSessionId}`}
+                className="text-xs text-blue-600 dark:text-blue-400 hover:underline font-normal"
+              >
+                {t('viewChildSession')}
+              </Link>
+            )}
+          </div>
+          <div className="text-sm text-gray-500 dark:text-gray-400 flex items-center">
+            {formatDateTime(firstMessageDate, localeForDate)}
+            {group.role === 'assistant' && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="ml-2">
+                    <Brain className={`w-4 h-4 ${getBrainColor(thinkingBudget)}`} />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>
+                    {group.messages.find((msg) => msg.thinkingBudget)
+                      ? `${t('thinkingBudget')}: ${thinkingBudget.toLocaleString()}`
+                      : `${t('thinkingBudget')}: ${t('defaultThinkingBudget')}`}
+                  </p>
+                  {!group.messages.find((msg) => msg.thinkingBudget) && (
+                    <p className="text-xs mt-1">{t('ultrathinkInstruction')}</p>
+                  )}
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+        </div>
+      )}
 
       <div className="space-y-1">
         {group.messages.map((message, index) => {
@@ -102,6 +135,7 @@ export const MessageGroupComponent = React.memo(function MessageGroupComponent({
               message={message}
               showTimestamp={showTimestamp}
               onInterrupt={isLastExecutingTool ? onInterrupt : undefined}
+              agentName={agentName}
             />
           );
         })}

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageItem.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageItem.tsx
@@ -6,6 +6,7 @@ import { MessageView } from './MessageList';
 import { MarkdownRenderer } from './MarkdownRenderer';
 import { ToolUseRenderer } from './ToolUseRenderer';
 import { EventTriggerRenderer } from './EventTriggerRenderer';
+import { AgentMessageRenderer } from './AgentMessageRenderer';
 import { ImageViewer } from './ImageViewer';
 import { FileViewer } from './FileViewer';
 import { formatTime } from '@/lib/utils';
@@ -14,9 +15,15 @@ type MessageItemProps = {
   message: MessageView;
   showTimestamp: boolean;
   onInterrupt?: () => void;
+  agentName?: string;
 };
 
-export const MessageItem = React.memo(function MessageItem({ message, showTimestamp, onInterrupt }: MessageItemProps) {
+export const MessageItem = React.memo(function MessageItem({
+  message,
+  showTimestamp,
+  onInterrupt,
+  agentName,
+}: MessageItemProps) {
   const t = useTranslations('sessions');
   const locale = useLocale();
   const localeForDate = locale === 'ja' ? 'ja-JP' : 'en-US';
@@ -53,6 +60,8 @@ export const MessageItem = React.memo(function MessageItem({ message, showTimest
           />
         ) : message.type === 'eventTrigger' ? (
           <EventTriggerRenderer name={message.detail} content={message.content} />
+        ) : message.type === 'agentMessage' ? (
+          <AgentMessageRenderer message={message} agentName={agentName} />
         ) : message.pending ? (
           <div className="pb-2 break-all">
             <span className="text-sm animate-shimmer-text bg-clip-text text-transparent bg-[length:200%_auto] whitespace-pre-wrap">

--- a/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MessageList.tsx
@@ -15,13 +15,23 @@ export type MessageView = {
   detail?: string;
   output?: string; // Added for toolResult output JSON
   timestamp: Date;
-  type: 'message' | 'toolResult' | 'toolUse' | 'eventTrigger';
+  type: 'message' | 'toolResult' | 'toolUse' | 'eventTrigger' | 'agentMessage';
   imageKeys?: string[];
   fileKeys?: string[];
   thinkingBudget?: number;
   reasoningText?: string;
   modelOverride?: ModelType;
   pending?: boolean;
+  agentName?: string;
+  childSessionId?: string;
+  /** For agentMessage: sender info */
+  senderSessionId?: string;
+  senderAgentName?: string;
+  /** For agentMessage on parent view: target info */
+  targetSessionId?: string;
+  targetAgentName?: string;
+  /** Whether this is an acknowledge (non-waking) message */
+  isAcknowledge?: boolean;
 };
 
 export type MessageGroup = {
@@ -39,6 +49,7 @@ type MessageListProps = {
   agentIconUrl?: string;
   agentName?: string;
   lastReadAt?: number;
+  childSessions?: { workerId: string; title?: string }[];
 };
 
 export default function MessageList({
@@ -49,6 +60,7 @@ export default function MessageList({
   agentIconUrl,
   agentName,
   lastReadAt,
+  childSessions,
 }: MessageListProps) {
   const t = useTranslations('sessions');
   const { userScrolledUp } = useScrollPosition();
@@ -59,14 +71,27 @@ export default function MessageList({
     let currentGroup: MessageGroup | null = null;
 
     messages.forEach((message) => {
-      if (!currentGroup || currentGroup.role !== message.role) {
+      // Agent messages always start a new group (each has its own sender context)
+      const isAgentMsg = message.type === 'agentMessage';
+      const prevIsAgentMsg = currentGroup?.messages[0]?.type === 'agentMessage';
+
+      // Start a new group if: different role, different agentName, or agent message boundary
+      const currentAgentName = currentGroup?.messages[0]?.agentName;
+      const isSameSource =
+        currentGroup &&
+        currentGroup.role === message.role &&
+        currentAgentName === message.agentName &&
+        !isAgentMsg &&
+        !prevIsAgentMsg;
+
+      if (!isSameSource) {
         currentGroup = {
           role: message.role,
           messages: [message],
         };
         groups.push(currentGroup);
       } else {
-        currentGroup.messages.push(message);
+        currentGroup!.messages.push(message);
       }
     });
 

--- a/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
@@ -51,6 +51,8 @@ interface SessionPageClientProps {
   agentName?: string;
   unreadMap?: Record<string, { unreadCount: number; hasPending: boolean }>;
   lastReadAt?: number;
+  childSessions?: { workerId: string; title?: string }[];
+  parentSessionId?: string;
 }
 
 export default function SessionPageClient({
@@ -67,6 +69,7 @@ export default function SessionPageClient({
   agentName,
   unreadMap,
   lastReadAt,
+  parentSessionId,
 }: SessionPageClientProps) {
   const t = useTranslations('sessions');
   const router = useRouter();
@@ -316,6 +319,8 @@ export default function SessionPageClient({
                   thinkingBudget: event.thinkingBudget,
                 },
               ]);
+            } else if (['sendMessageToAgent', 'acknowledgeAgent'].includes(event.toolName)) {
+              // Agent-to-agent tools are silent in local view; shown via agentMessage events on parent
             } else {
               setMessages((prev) => [
                 ...prev,
@@ -336,6 +341,23 @@ export default function SessionPageClient({
               refetchTodoList({ workerId });
             }
 
+            break;
+          case 'agentMessage':
+            setMessages((prev) => [
+              ...prev,
+              {
+                id: `agent-msg-${event.timestamp}`,
+                role: 'user',
+                content: event.message,
+                timestamp: new Date(event.timestamp),
+                type: 'agentMessage',
+                senderSessionId: event.senderSessionId,
+                senderAgentName: event.senderName,
+                targetSessionId: event.targetSessionId,
+                targetAgentName: event.targetName,
+                isAcknowledge: event.acknowledge,
+              },
+            ]);
             break;
         }
       },

--- a/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/SessionPageClient.tsx
@@ -319,7 +319,7 @@ export default function SessionPageClient({
                   thinkingBudget: event.thinkingBudget,
                 },
               ]);
-            } else if (['sendMessageToAgent', 'acknowledgeAgent'].includes(event.toolName)) {
+            } else if (['sendMessageToAgent', 'acknowledgeAgent', 'confirmSendToUser'].includes(event.toolName)) {
               // Agent-to-agent tools are silent in local view; shown via agentMessage events on parent
             } else {
               setMessages((prev) => [

--- a/packages/webapp/src/app/sessions/[workerId]/component/SessionSidebar.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/SessionSidebar.tsx
@@ -11,6 +11,19 @@ import { useRouter } from 'next/navigation';
 import type { UnreadMap } from '@remote-swe-agents/agent-core/lib';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
+type SortKey = 'createdAt' | 'updatedAt' | 'lastMessageAt' | 'sessionCost';
+type SortOrder = 'desc' | 'asc';
+
+function hasWorkingDescendant(parentId: string, childrenMap: Record<string, SessionItem[]>): boolean {
+  const children = childrenMap[parentId];
+  if (!children) return false;
+  for (const child of children) {
+    if (child.agentStatus === 'working') return true;
+    if (hasWorkingDescendant(child.workerId, childrenMap)) return true;
+  }
+  return false;
+}
+
 interface SessionSidebarProps {
   currentWorkerId: string;
   sessions: SessionItem[];
@@ -40,6 +53,27 @@ export default function SessionSidebar({
   const navRef = useRef<HTMLElement>(null);
   const [navHeight, setNavHeight] = useState(0);
   const scrollYRef = useRef(0);
+  const [sortKey, setSortKey] = useState<SortKey>('lastMessageAt');
+  const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
+
+  // Sync sort settings from localStorage (shared with session list page)
+  useEffect(() => {
+    const savedSortKey = localStorage.getItem('sessions-sort-key') as SortKey | null;
+    const savedSortOrder = localStorage.getItem('sessions-sort-order') as SortOrder | null;
+    if (savedSortKey) setSortKey(savedSortKey);
+    if (savedSortOrder) setSortOrder(savedSortOrder);
+
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === 'sessions-sort-key' && e.newValue) {
+        setSortKey(e.newValue as SortKey);
+      }
+      if (e.key === 'sessions-sort-order' && e.newValue) {
+        setSortOrder(e.newValue as SortOrder);
+      }
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
 
   useEffect(() => {
     const el = navRef.current;
@@ -137,7 +171,6 @@ export default function SessionSidebar({
               });
             });
           }
-          // Handle unreadUpdate events from backend
           if (event.type === 'unreadUpdate') {
             if (event.userId !== userId) return;
             onUnreadUpdate?.(event.workerId, { unreadCount: event.unreadCount, hasPending: event.hasPending });
@@ -152,9 +185,106 @@ export default function SessionSidebar({
 
   const sortedSessions = useMemo(() => {
     return [...sessions]
-      .filter((session) => session.agentStatus !== 'completed')
-      .sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
-  }, [sessions]);
+      .filter((session) => session.agentStatus !== 'completed' || session.workerId === currentWorkerId)
+      .sort((a, b) => {
+        let aVal: number;
+        let bVal: number;
+        if (sortKey === 'lastMessageAt') {
+          aVal = a.lastMessageAt ?? a.updatedAt ?? 0;
+          bVal = b.lastMessageAt ?? b.updatedAt ?? 0;
+        } else {
+          aVal = Number(a[sortKey] ?? 0);
+          bVal = Number(b[sortKey] ?? 0);
+        }
+        return sortOrder === 'desc' ? bVal - aVal : aVal - bVal;
+      });
+  }, [sessions, sortKey, sortOrder]);
+
+  // Build parent-child map for sidebar grouping
+  const childrenMap = useMemo(() => {
+    const map: Record<string, SessionItem[]> = {};
+    for (const session of sortedSessions) {
+      if (session.parentSessionId) {
+        if (!map[session.parentSessionId]) {
+          map[session.parentSessionId] = [];
+        }
+        map[session.parentSessionId].push(session);
+      }
+    }
+    return map;
+  }, [sortedSessions]);
+
+  const rootSessions = useMemo(() => {
+    return sortedSessions.filter((s) => !s.parentSessionId);
+  }, [sortedSessions]);
+
+  // Auto-expand: show descendants of the current session and its ancestor chain
+  const expandedGroupIds = useMemo(() => {
+    const set = new Set<string>();
+    // Walk up the ancestor chain from the current session
+    let current = sortedSessions.find((s) => s.workerId === currentWorkerId);
+    while (current) {
+      if (current.parentSessionId) {
+        set.add(current.parentSessionId);
+        current = sortedSessions.find((s) => s.workerId === current!.parentSessionId);
+      } else {
+        break;
+      }
+    }
+    // Also expand current session and all its descendants
+    const expandDescendants = (id: string) => {
+      if (childrenMap[id]?.length) {
+        set.add(id);
+        for (const child of childrenMap[id]) {
+          expandDescendants(child.workerId);
+        }
+      }
+    };
+    expandDescendants(currentWorkerId);
+    return set;
+  }, [currentWorkerId, sortedSessions, childrenMap]);
+
+  const renderChildren = (children: SessionItem[], depth: number) => {
+    const paddingLeft = 6 + depth * 4; // pl-10, pl-14, pl-18, etc.
+    return children.map((child) => {
+      const childStatus = getUnifiedStatus(child.agentStatus, child.instanceStatus);
+      const isChildCurrent = child.workerId === currentWorkerId;
+      const grandchildren = childrenMap[child.workerId] ?? [];
+      const hasGrandchildren = grandchildren.length > 0;
+      const isChildExpanded = expandedGroupIds.has(child.workerId);
+      return (
+        <div key={child.workerId}>
+          <Link
+            href={`/sessions/${child.workerId}`}
+            onClick={onClose}
+            className={`flex items-center gap-2 pr-3 py-2 mx-1 rounded-md transition-colors text-left`}
+            style={{ paddingLeft: `${paddingLeft * 4}px` }}
+          >
+            <span
+              className={`inline-block w-1.5 h-1.5 rounded-full flex-shrink-0 ${childStatus.color} ${
+                isChildCurrent ? '' : ''
+              }`}
+            />
+            <span
+              className={`text-xs truncate flex-1 ${
+                isChildCurrent
+                  ? 'text-blue-700 dark:text-blue-300 font-semibold'
+                  : 'text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200'
+              }`}
+            >
+              {child.title || child.SK}
+            </span>
+            {unreadMap[child.workerId]?.unreadCount > 0 && (
+              <span className="flex-shrink-0 min-w-4 h-4 px-1 rounded-full bg-blue-600 text-white text-[10px] font-bold flex items-center justify-center">
+                {unreadMap[child.workerId].unreadCount}
+              </span>
+            )}
+          </Link>
+          {hasGrandchildren && isChildExpanded && renderChildren(grandchildren, depth + 1)}
+        </div>
+      );
+    });
+  };
 
   return (
     <>
@@ -211,28 +341,39 @@ export default function SessionSidebar({
           style={{ WebkitOverflowScrolling: 'touch' }}
         >
           <div className="py-1" style={{ minHeight: navHeight > 0 ? navHeight + 1 : undefined }}>
-            {sortedSessions.map((session) => {
-              const status = getUnifiedStatus(session.agentStatus, session.instanceStatus);
+            {rootSessions.map((session) => {
+              const hasWorkingChild = hasWorkingDescendant(session.workerId, childrenMap);
+              const status =
+                hasWorkingChild && session.agentStatus !== 'working'
+                  ? getUnifiedStatus('working', session.instanceStatus)
+                  : getUnifiedStatus(session.agentStatus, session.instanceStatus);
               const isCurrent = session.workerId === currentWorkerId;
+              const children = childrenMap[session.workerId] ?? [];
+              const hasChildren = children.length > 0;
+              const isExpanded = expandedGroupIds.has(session.workerId);
               return (
-                <Link
-                  key={session.workerId}
-                  href={`/sessions/${session.workerId}`}
-                  onClick={onClose}
-                  className={`flex items-center gap-2.5 px-3 py-2.5 mx-1 rounded-md transition-colors text-left ${
-                    isCurrent
-                      ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300'
-                      : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
-                  }`}
-                >
-                  <span className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${status.color}`} />
-                  <span className="text-sm truncate flex-1">{session.title || session.SK}</span>
-                  {unreadMap[session.workerId]?.unreadCount > 0 && (
-                    <span className="flex-shrink-0 min-w-4 h-4 px-1 rounded-full bg-blue-600 text-white text-[10px] font-bold flex items-center justify-center">
-                      {unreadMap[session.workerId].unreadCount}
-                    </span>
-                  )}
-                </Link>
+                <div key={session.workerId}>
+                  <div className="flex items-center mx-1">
+                    <Link
+                      href={`/sessions/${session.workerId}`}
+                      onClick={onClose}
+                      className={`flex items-center gap-2.5 px-2 py-2.5 rounded-md transition-colors text-left flex-1 min-w-0 ${
+                        isCurrent
+                          ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300'
+                          : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                      }`}
+                    >
+                      <span className={`inline-block w-2 h-2 rounded-full flex-shrink-0 ${status.color}`} />
+                      <span className="text-sm truncate flex-1">{session.title || session.SK}</span>
+                      {unreadMap[session.workerId]?.unreadCount > 0 && (
+                        <span className="flex-shrink-0 min-w-4 h-4 px-1 rounded-full bg-blue-600 text-white text-[10px] font-bold flex items-center justify-center">
+                          {unreadMap[session.workerId].unreadCount}
+                        </span>
+                      )}
+                    </Link>
+                  </div>
+                  {hasChildren && isExpanded && renderChildren(children, 1)}
+                </div>
               );
             })}
           </div>

--- a/packages/webapp/src/app/sessions/[workerId]/page.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/page.tsx
@@ -38,7 +38,7 @@ export default async function SessionPage({ params }: PageProps<'/sessions/[work
   const isMsg = (toolName: string | undefined) =>
     ['sendMessageToUser', 'sendMessageToUserIfNecessary', 'sendImageToUser', 'sendFileToUser'].includes(toolName ?? '');
   const isHiddenTool = (toolName: string | undefined) =>
-    isMsg(toolName) || ['sendMessageToAgent', 'acknowledgeAgent'].includes(toolName ?? '');
+    isMsg(toolName) || ['sendMessageToAgent', 'acknowledgeAgent', 'confirmSendToUser'].includes(toolName ?? '');
 
   // Collect all completed toolUseIds from toolResult messages
   const completedToolUseIds = new Set<string>();

--- a/packages/webapp/src/app/sessions/[workerId]/page.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/page.tsx
@@ -16,11 +16,8 @@ import SessionPageClient from './component/SessionPageClient';
 import { MessageView } from './component/MessageList';
 import { notFound } from 'next/navigation';
 import { RefreshOnFocus } from '@/components/RefreshOnFocus';
-import { extractUserMessage, formatMessage } from '@/lib/message-formatter';
+import { extractUserMessage, formatMessage, stripAgentMessagePrefix } from '@/lib/message-formatter';
 import { getSession as getAuthSession } from '@/lib/auth';
-import { GetObjectCommand } from '@aws-sdk/client-s3';
-import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { s3, BucketName } from '@remote-swe-agents/agent-core/aws';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -40,6 +37,8 @@ export default async function SessionPage({ params }: PageProps<'/sessions/[work
   const messages: MessageView[] = [];
   const isMsg = (toolName: string | undefined) =>
     ['sendMessageToUser', 'sendMessageToUserIfNecessary', 'sendImageToUser', 'sendFileToUser'].includes(toolName ?? '');
+  const isHiddenTool = (toolName: string | undefined) =>
+    isMsg(toolName) || ['sendMessageToAgent', 'acknowledgeAgent'].includes(toolName ?? '');
 
   // Collect all completed toolUseIds from toolResult messages
   const completedToolUseIds = new Set<string>();
@@ -150,7 +149,7 @@ export default async function SessionPage({ params }: PageProps<'/sessions/[work
 
         const tools = (message.content ?? [])
           .filter((c) => c.toolUse != undefined)
-          .filter((c) => !isMsg(c.toolUse.name));
+          .filter((c) => !isHiddenTool(c.toolUse.name));
 
         if (tools.length > 0) {
           const content = tools.map((block) => block.toolUse.name).join(' + ');
@@ -234,6 +233,24 @@ export default async function SessionPage({ params }: PageProps<'/sessions/[work
         });
         break;
       }
+      case 'agentMessage': {
+        const text = (message.content?.map((c) => c.text).filter((c) => c) ?? []).join('\n');
+        const extracted = stripAgentMessagePrefix(extractUserMessage(text));
+
+        messages.push({
+          id: `${item.SK}-${i}`,
+          role: 'user',
+          content: extracted,
+          timestamp: new Date(parseInt(item.SK)),
+          type: 'agentMessage',
+          senderSessionId: item.senderSessionId,
+          senderAgentName: item.senderAgentName,
+          targetSessionId: item.targetSessionId,
+          targetAgentName: item.targetAgentName,
+          isAcknowledge: item.isAcknowledge,
+        });
+        break;
+      }
       case 'assistant': {
         const text = (message.content?.map((c) => c.text).filter((c) => c) ?? []).join('\n');
         const formatted = formatMessage(text);
@@ -271,18 +288,12 @@ export default async function SessionPage({ params }: PageProps<'/sessions/[work
   const { userId } = await getAuthSession();
   const [unreadMap, lastReadAt] = await Promise.all([getUnreadMap(userId), getLastReadAt(userId, workerId)]);
 
-  // Resolve agent icon URL
+  // Resolve agent icon URL via /api/agent-icon route (cached by CloudFront)
   let agentIconUrl: string | undefined;
   const customAgent = session.customAgentId ? await getCustomAgent(session.customAgentId) : undefined;
   const iconKey = customAgent?.iconKey || preferences.defaultAgentIconKey;
   if (iconKey) {
-    try {
-      agentIconUrl = await getSignedUrl(s3, new GetObjectCommand({ Bucket: BucketName, Key: iconKey }), {
-        expiresIn: 3600,
-      });
-    } catch {
-      // Ignore errors, fall back to default icon
-    }
+    agentIconUrl = `/api/agent-icon?key=${encodeURIComponent(iconKey)}`;
   }
 
   return (
@@ -298,9 +309,10 @@ export default async function SessionPage({ params }: PageProps<'/sessions/[work
         initialTodoList={todoList}
         allSessions={allSessions}
         agentIconUrl={agentIconUrl}
-        agentName={customAgent?.name || preferences.defaultAgentName || undefined}
+        agentName={session.agentName || customAgent?.name || preferences.defaultAgentName || undefined}
         unreadMap={unreadMap}
         lastReadAt={lastReadAt}
+        parentSessionId={session.parentSessionId}
       />
       <RefreshOnFocus />
     </>

--- a/packages/webapp/src/app/sessions/new/page.tsx
+++ b/packages/webapp/src/app/sessions/new/page.tsx
@@ -3,10 +3,8 @@ import { ArrowLeft, MessageSquare } from 'lucide-react';
 import Link from 'next/link';
 import { getTranslations } from 'next-intl/server';
 import NewSessionForm from './NewSessionForm';
-import { ddb, TableName, s3, BucketName } from '@remote-swe-agents/agent-core/aws';
+import { ddb, TableName } from '@remote-swe-agents/agent-core/aws';
 import { QueryCommand } from '@aws-sdk/lib-dynamodb';
-import { GetObjectCommand } from '@aws-sdk/client-s3';
-import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { PromptTemplate } from '@/app/sessions/new/schemas';
 import { getCustomAgents, getPreferences } from '@remote-swe-agents/agent-core/lib';
 
@@ -31,19 +29,11 @@ export default async function NewSessionPage() {
 
   templates = (result.Items ?? []) as PromptTemplate[];
 
-  // Resolve agent icon URLs
+  // Resolve agent icon URLs via /api/agent-icon route (cached by CloudFront)
   const agentIconUrls: Record<string, string> = {};
   for (const agent of customAgents) {
     if (agent.iconKey) {
-      try {
-        agentIconUrls[agent.SK] = await getSignedUrl(
-          s3,
-          new GetObjectCommand({ Bucket: BucketName, Key: agent.iconKey }),
-          { expiresIn: 3600 }
-        );
-      } catch {
-        // Ignore errors
-      }
+      agentIconUrls[agent.SK] = `/api/agent-icon?key=${encodeURIComponent(agent.iconKey)}`;
     }
   }
 

--- a/packages/webapp/src/lib/message-formatter.ts
+++ b/packages/webapp/src/lib/message-formatter.ts
@@ -59,3 +59,11 @@ export function extractUserMessage(message: string | undefined): string {
     .slice(message.indexOf('<user_message>') + '<user_message>'.length, message.indexOf('</user_message>'))
     .trim();
 }
+
+/**
+ * Strips the "[Message from AgentName]: " prefix from agent-to-agent messages.
+ * The sender name is already shown in the UI header, so the prefix is redundant.
+ */
+export function stripAgentMessagePrefix(message: string): string {
+  return message.replace(/^\[Message from [^\]]+\]:\s*/, '');
+}

--- a/packages/webapp/src/messages/en.json
+++ b/packages/webapp/src/messages/en.json
@@ -51,7 +51,7 @@
     "agentStartingMessage": "The AI agent is starting up. This may take up to 2 minutes. Please wait...",
     "aiAgentResponding": "{agentName} is thinking...",
     "enterYourMessage": "Enter your message...",
-    "waitingForImageUpload": "Waiting for image upload...",
+    "waitingForImageUpload": "Waiting for upload...",
     "noSessionsFound": "No sessions found",
     "createSessionToStart": "Create a new session to start chatting with AI agents",
     "usingTool": "Using Tool",
@@ -122,7 +122,12 @@
     "stopSessionSuccess": "Session stopped",
     "stopSessionError": "Failed to stop session",
     "newMessages": "New Messages",
-    "showOlderMessages": "Show {count} older messages"
+    "showOlderMessages": "Show {count} older messages",
+    "childSessions": "{count} child sessions",
+    "viewChildSession": "View details",
+    "viewSession": "View",
+    "deleteGroup": "Delete Group",
+    "deleteGroupConfirm": "Are you sure you want to delete this session and its {count} child sessions? This action cannot be undone."
   },
   "home": {
     "title": "Welcome to Remote SWE Agents",
@@ -203,7 +208,7 @@
     "createSessionButton": "Create Session & Start Conversation",
     "addImage": "Add Image",
     "imagesCount": "{count} images",
-    "waitingForImageUpload": "Waiting for image upload...",
+    "waitingForImageUpload": "Waiting for upload...",
     "templates": "Templates",
     "modelOverride": "Model",
     "customAgent": "Custom Agent",

--- a/packages/webapp/src/messages/ja.json
+++ b/packages/webapp/src/messages/ja.json
@@ -51,7 +51,7 @@
     "agentStartingMessage": "AIエージェントが起動中です。最大で2分ほどかかる場合があります。しばらくお待ちください...",
     "aiAgentResponding": "{agentName}が思考中...",
     "enterYourMessage": "メッセージを入力...",
-    "waitingForImageUpload": "画像アップロード中...",
+    "waitingForImageUpload": "アップロード中...",
     "noSessionsFound": "セッションが見つかりません",
     "createSessionToStart": "AIエージェントとチャットするには新規セッションを作成してください",
     "usingTool": "ツール使用",
@@ -122,7 +122,12 @@
     "stopSessionSuccess": "セッションを停止しました",
     "stopSessionError": "セッションの停止に失敗しました",
     "newMessages": "新着メッセージ",
-    "showOlderMessages": "{count}件の古いメッセージを表示"
+    "showOlderMessages": "{count}件の古いメッセージを表示",
+    "childSessions": "子セッション {count}件",
+    "viewChildSession": "詳細を見る",
+    "viewSession": "表示",
+    "deleteGroup": "グループ削除",
+    "deleteGroupConfirm": "このセッションと{count}件の子セッションを削除しますか？この操作は取り消せません。"
   },
   "home": {
     "title": "Remote SWE Agents へようこそ",
@@ -202,7 +207,7 @@
     "createSessionButton": "セッションを作成して会話を開始",
     "addImage": "画像を追加",
     "imagesCount": "{count} 枚の画像",
-    "waitingForImageUpload": "画像アップロード中...",
+    "waitingForImageUpload": "アップロード中...",
     "templates": "テンプレート",
     "modelOverride": "モデル",
     "customAgent": "カスタムエージェント",

--- a/packages/worker/src/agent/index.test.ts
+++ b/packages/worker/src/agent/index.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+import { shouldResetReportTimer, toolNamesThatResetReportTimer } from './index';
+
+describe('shouldResetReportTimer', () => {
+  test('returns true for sendMessageToUser', () => {
+    expect(shouldResetReportTimer('sendMessageToUser')).toBe(true);
+  });
+
+  test('returns true for sendMessageToAgent', () => {
+    expect(shouldResetReportTimer('sendMessageToAgent')).toBe(true);
+  });
+
+  test('returns true for acknowledgeAgent', () => {
+    expect(shouldResetReportTimer('acknowledgeAgent')).toBe(true);
+  });
+
+  test('returns false for unrelated tools', () => {
+    expect(shouldResetReportTimer('executeCommand')).toBe(false);
+    expect(shouldResetReportTimer('fileEditor')).toBe(false);
+    expect(shouldResetReportTimer('cloneGitHubRepository')).toBe(false);
+  });
+
+  test('returns false for undefined', () => {
+    expect(shouldResetReportTimer(undefined)).toBe(false);
+  });
+
+  test('returns false for empty string', () => {
+    expect(shouldResetReportTimer('')).toBe(false);
+  });
+});
+
+describe('toolNamesThatResetReportTimer', () => {
+  test('contains exactly the three expected tool names', () => {
+    expect(toolNamesThatResetReportTimer.size).toBe(3);
+    expect(toolNamesThatResetReportTimer.has('sendMessageToUser')).toBe(true);
+    expect(toolNamesThatResetReportTimer.has('sendMessageToAgent')).toBe(true);
+    expect(toolNamesThatResetReportTimer.has('acknowledgeAgent')).toBe(true);
+  });
+});

--- a/packages/worker/src/agent/index.ts
+++ b/packages/worker/src/agent/index.ts
@@ -22,7 +22,9 @@ import {
   getPreferences,
   getCustomAgent,
   updateSessionLastMessage,
+  getChildSessions,
 } from '@remote-swe-agents/agent-core/lib';
+import { resolveAgentDisplayName } from '@remote-swe-agents/agent-core/lib';
 import pRetry, { AbortError } from 'p-retry';
 import { bedrockConverse } from '@remote-swe-agents/agent-core/lib';
 import { getMcpToolSpecs, tryExecuteMcpTool } from './mcp';
@@ -33,6 +35,8 @@ import {
   gitHubTools,
   reportProgressTool,
   cloneRepositoryTool,
+  sendToAgentTool,
+  acknowledgeAgentTool,
 } from '@remote-swe-agents/agent-core/tools';
 import { findRepositoryKnowledge } from './lib/knowledge';
 import { sendWebappEvent } from '@remote-swe-agents/agent-core/lib';
@@ -41,6 +45,25 @@ import { updateAgentStatusWithEvent } from '../common/status';
 import { refreshSession } from '../common/refresh-session';
 import { DefaultAgent, getEssentialSystemPrompt, getDefaultKnowledgePrompt } from './lib/default-agent';
 import { EmptyMcpConfig, mcpConfigSchema, modelConfigs, ModelType } from '@remote-swe-agents/agent-core/schema';
+
+/**
+ * Tool names that should reset the lastReportedTime timer.
+ * This includes tools that communicate with users OR other agents,
+ * preventing the forceReport mechanism from firing unnecessarily
+ * (especially in child sessions that primarily use agent-to-agent communication).
+ */
+export const toolNamesThatResetReportTimer = new Set([
+  reportProgressTool.name,
+  sendToAgentTool.name,
+  acknowledgeAgentTool.name,
+]);
+
+/**
+ * Check whether the given tool name should reset the lastReportedTime.
+ */
+export const shouldResetReportTimer = (toolName: string | undefined): boolean => {
+  return toolName != null && toolNamesThatResetReportTimer.has(toolName);
+};
 
 const agentLoop = async (workerId: string, cancellationToken: CancellationToken) => {
   const session = await getSession(workerId);
@@ -68,6 +91,7 @@ const agentLoop = async (workerId: string, cancellationToken: CancellationToken)
         lastItem == null ||
         lastItem.messageType === 'userMessage' ||
         lastItem.messageType === 'eventTrigger' ||
+        lastItem.messageType === 'agentMessage' ||
         attemptCount > 4
       ) {
         return res;
@@ -139,6 +163,90 @@ const agentLoop = async (workerId: string, cancellationToken: CancellationToken)
     }
   };
   await tryAppendRepositoryKnowledge();
+
+  // Inject session hierarchy information for parent-child communication
+  if (session) {
+    const hierarchyLines: string[] = [];
+    const selfName = await resolveAgentDisplayName(session);
+
+    if (session.parentSessionId) {
+      const parentSession = await getSession(session.parentSessionId);
+      const parentName = parentSession ? await resolveAgentDisplayName(parentSession) : session.parentSessionId;
+      hierarchyLines.push(`You are a child agent "${selfName}" (Session ID: ${workerId}).`);
+      hierarchyLines.push(`Parent: "${parentName}" (Session ID: ${session.parentSessionId})`);
+      hierarchyLines.push('');
+      hierarchyLines.push('### Message Routing Rules for Child Sessions');
+      hierarchyLines.push('Always reply to whoever sent you the message:');
+      hierarchyLines.push(
+        '- **Parent agent** (via `sendMessageToAgent`) → Reply with `sendMessageToAgent` to the parent.'
+      );
+      hierarchyLines.push("- **User** (typed directly in this session's WebUI) → Reply with `sendMessageToUser`.");
+      hierarchyLines.push('- **Event trigger** (no sender) → Report to the parent with `sendMessageToAgent`.');
+      hierarchyLines.push('');
+      hierarchyLines.push(
+        'IMPORTANT: After calling `sendMessageToUser` or `sendMessageToAgent`, end your turn with NO text output. Text output at end-of-turn is also delivered to the user, causing duplicate messages.'
+      );
+      hierarchyLines.push('Use `acknowledgeAgent` for lightweight responses that do not need immediate action.');
+
+      // Get siblings
+      const siblings = await getChildSessions(session.parentSessionId);
+      const otherSiblings = siblings.filter((s) => s.workerId !== workerId);
+      if (otherSiblings.length > 0) {
+        hierarchyLines.push('');
+        hierarchyLines.push('Siblings:');
+        for (const sib of otherSiblings) {
+          const sibName = await resolveAgentDisplayName(sib);
+          hierarchyLines.push(`- "${sibName}" (Session ID: ${sib.workerId})`);
+        }
+      }
+    } else {
+      // Check if this session has children
+      const children = await getChildSessions(workerId);
+      if (children.length > 0) {
+        hierarchyLines.push(`You are a parent agent "${selfName}" (Session ID: ${workerId}).`);
+        hierarchyLines.push('Your child agents:');
+        for (const child of children) {
+          const childName = await resolveAgentDisplayName(child);
+          hierarchyLines.push(`- "${childName}" (Session ID: ${child.workerId})`);
+        }
+      }
+
+      // Check if this session was created by another session (independent session)
+      if (session.creatorSessionId) {
+        const creatorSession = await getSession(session.creatorSessionId);
+        const creatorName = creatorSession ? await resolveAgentDisplayName(creatorSession) : session.creatorSessionId;
+        hierarchyLines.push('');
+        hierarchyLines.push(`This session was created by: "${creatorName}" (Session ID: ${session.creatorSessionId})`);
+        hierarchyLines.push(
+          'You can use sendMessageToAgent to communicate with the creator session if you need more context or have questions.'
+        );
+      }
+    }
+
+    if (hierarchyLines.length > 0) {
+      hierarchyLines.push('');
+      hierarchyLines.push('Use sendMessageToAgent to send messages to other agents by session ID.');
+      hierarchyLines.push('Use acknowledgeAgent to respond without waking up the target (like a read receipt).');
+      hierarchyLines.push('');
+      hierarchyLines.push('### Child vs Independent Session Decision');
+      hierarchyLines.push('When creating new sessions with `createNewSession`:');
+      hierarchyLines.push(
+        "- **Child session (asChild=true)**: Use ONLY when the task is directly related to the CURRENT session's topic. Child sessions are deleted when the parent session ends."
+      );
+      hierarchyLines.push(
+        '- **Independent session (asChild=false)**: Use when the task is a DIFFERENT topic from the current session. Independent sessions persist on their own.'
+      );
+      hierarchyLines.push('');
+      hierarchyLines.push('Examples:');
+      hierarchyLines.push(
+        '- Current session is about "API performance tuning" → Run a load test → Child session (sub-task of the same topic)'
+      );
+      hierarchyLines.push(
+        '- Current session is about "API performance tuning" → Fix a typo in the README → Independent session (unrelated topic)'
+      );
+      systemPrompt = `${systemPrompt}\n\n## Session Hierarchy\n${hierarchyLines.join('\n')}`;
+    }
+  }
 
   await refreshSession(workerId);
 
@@ -437,7 +545,7 @@ const agentLoop = async (workerId: string, cancellationToken: CancellationToken)
             }
           }
 
-          if (name == reportProgressTool.name) {
+          if (shouldResetReportTimer(name)) {
             lastReportedTime = Date.now();
           }
           if (name == cloneRepositoryTool.name) {
@@ -454,7 +562,11 @@ const agentLoop = async (workerId: string, cancellationToken: CancellationToken)
             toolUseId,
             content: toolResultObject ?? [
               {
-                text: renderToolResult({ toolResult, forceReport: Date.now() - lastReportedTime > 300 * 1000 }),
+                text: renderToolResult({
+                  toolResult,
+                  forceReport: Date.now() - lastReportedTime > 300 * 1000,
+                  parentSessionId: session?.parentSessionId,
+                }),
               },
             ],
           },
@@ -493,6 +605,16 @@ const agentLoop = async (workerId: string, cancellationToken: CancellationToken)
       }
 
       // Save toolResult message to DynamoDB after all tools have been executed
+      // If the assistant included text blocks alongside tool calls, append a warning to the last tool result
+      const textBlocks = toolUseMessage.content?.filter((c) => 'text' in c && c.text) ?? [];
+      if (textBlocks.length > 0) {
+        const lastToolResult = toolResultMessage.content!.findLast((c) => c.toolResult);
+        if (lastToolResult?.toolResult?.content) {
+          lastToolResult.toolResult.content.push({
+            text: '\n<system>WARNING: Your previous response included text blocks alongside tool calls. These text blocks were NOT delivered to the user. If the text was intended for the user, you must resend it using the sendMessageToUser tool.</system>',
+          });
+        }
+      }
       const savedToolResultItem = await saveToolResultMessage(workerId, toolResultMessage, savedToolUseItem.SK);
       appendedItems.push(savedToolUseItem, savedToolResultItem);
     } else {
@@ -511,6 +633,25 @@ const agentLoop = async (workerId: string, cancellationToken: CancellationToken)
       const responseText = finalMessage.content?.at(-1)?.text ?? finalMessage.content?.at(0)?.text ?? '';
       // remove <thinking> </thinking> part with multiline support
       const responseTextWithoutThinking = responseText.replace(/<thinking>[\s\S]*?<\/thinking>/g, '');
+
+      // If this is a child session and the last incoming message was from an agent,
+      // redirect the end-of-turn response to the parent agent
+      if (session?.parentSessionId) {
+        const lastIncoming = [...initialItems, ...appendedItems].filter((i) => i.role === 'user').at(-1);
+        if (lastIncoming?.messageType === 'agentMessage') {
+          try {
+            const { sendAgentMessage } = await import('@remote-swe-agents/agent-core/lib');
+            await sendAgentMessage({
+              senderWorkerId: workerId,
+              targetSessionIds: [session.parentSessionId],
+              message: responseTextWithoutThinking,
+              acknowledge: true,
+            });
+          } catch (e) {
+            console.error('[agent-loop] Failed to redirect end-of-turn to parent:', e);
+          }
+        }
+      }
 
       const lastMessagePreview = responseTextWithoutThinking.slice(0, 500);
       if (lastMessagePreview) {
@@ -553,6 +694,7 @@ export const resume = async (workerId: string, cancellationToken: CancellationTo
   if (
     lastItem?.messageType == 'userMessage' ||
     lastItem?.messageType == 'eventTrigger' ||
+    lastItem?.messageType == 'agentMessage' ||
     lastItem?.messageType == 'toolResult' ||
     lastItem?.messageType == 'toolUse' ||
     lastItem?.messageType == 'errorFeedback'

--- a/packages/worker/src/agent/lib/default-agent.ts
+++ b/packages/worker/src/agent/lib/default-agent.ts
@@ -47,10 +47,18 @@ Your output text is sent to the user only when 1. using ${reportProgressTool.nam
 - This means: do not write any text after your final tool usage if that tool was ${reportProgressTool.name}
 - Example: \`<last tool call is ${reportProgressTool.name}>\` → your turn ends with no additional text
 
+### IMPORTANT: Text blocks in tool call responses are NOT delivered to the user
+- When you return a response that includes both text blocks and tool_use blocks, ONLY the tool calls are processed. The text blocks are silently discarded.
+- If you need to communicate with the user AND call tools in the same turn, you MUST use ${reportProgressTool.name} tool for the message. Do not rely on plain text blocks alongside tool calls.
+
 ## Session Title
-- IMPORTANT: At the end of your FIRST turn, use ${updateSessionTitleTool.name} to set a descriptive session title based on the user's request.
-- If the conversation topic significantly changes later, update the title accordingly.
+- At the end of your FIRST turn, use ${updateSessionTitleTool.name} to set a descriptive session title based on the user's request.
+- IMPORTANT: Keep the title up-to-date throughout the conversation. If the main topic evolves or shifts, proactively update the title to reflect the current focus. Don't leave a stale title.
+- When the user explicitly asks to rename the session, do so immediately.
 - Keep titles concise (under 30 characters preferred) and use the same language as the user.
+
+## Tool Tips
+- sendFileToUser accepts S3 URIs (s3://bucket/key) directly in filePath. You don't need to download files locally first.
 `.trim();
 
 /**

--- a/packages/worker/src/common/status.ts
+++ b/packages/worker/src/common/status.ts
@@ -1,4 +1,10 @@
-import { updateSessionAgentStatus, sendWebappEvent, getSession, markPending } from '@remote-swe-agents/agent-core/lib';
+import {
+  updateSessionAgentStatus,
+  sendWebappEvent,
+  getSession,
+  markPending,
+  getConversationHistory,
+} from '@remote-swe-agents/agent-core/lib';
 
 /**
  * Updates the agent status and sends a corresponding webapp event
@@ -14,6 +20,17 @@ export async function updateAgentStatusWithEvent(workerId: string, status: 'work
     try {
       const session = await getSession(workerId);
       if (session?.initiator?.startsWith('webapp#')) {
+        // For child sessions, only mark pending if the last incoming message was from a user.
+        // This avoids unnecessary notifications when the child is just communicating with
+        // its parent agent or responding to event triggers.
+        if (session.parentSessionId) {
+          const { items } = await getConversationHistory(workerId);
+          const lastIncoming = items.filter((i) => i.role === 'user').at(-1);
+          if (lastIncoming?.messageType !== 'userMessage') {
+            return;
+          }
+        }
+
         const userId = session.initiator.replace('webapp#', '');
         await markPending(userId, workerId);
       }

--- a/packages/worker/src/entry.ts
+++ b/packages/worker/src/entry.ts
@@ -41,40 +41,63 @@ Amplify.configure(
 );
 
 class ConverseSessionTracker {
-  private sessions: { isFinished: boolean; cancellationToken: CancellationToken }[] = [];
+  private sessions: { promise: Promise<void>; isFinished: boolean; cancellationToken: CancellationToken }[] = [];
+  private operationQueue: Promise<void> = Promise.resolve();
   public constructor(private readonly workerId: string) {}
 
+  private enqueue(operation: () => Promise<void>): void {
+    this.operationQueue = this.operationQueue.then(operation).catch((e) => {
+      console.log('Operation queue error:', e);
+    });
+  }
+
   public startOnMessageReceived() {
-    const session = { isFinished: false, cancellationToken: new CancellationToken() };
+    this.enqueue(async () => {
+      await this.cancelCurrentSessions();
+      this._startOnMessageReceived();
+    });
+  }
+
+  public startResume() {
+    this.enqueue(async () => {
+      await this.cancelCurrentSessions();
+      this._startResume();
+    });
+  }
+
+  public forceStop(callback?: () => Promise<any>) {
+    this.enqueue(async () => {
+      await this.cancelCurrentSessions(callback);
+    });
+  }
+
+  private _startOnMessageReceived() {
+    const session = { promise: Promise.resolve(), isFinished: false, cancellationToken: new CancellationToken() };
     this.sessions.push(session);
     // temporarily pause kill timer when an agent loop is running
     const restartToken = pauseKillTimer();
-    onMessageReceived(this.workerId, session.cancellationToken)
-      .then(() => {
-        session.isFinished = true;
-      })
+    session.promise = onMessageReceived(this.workerId, session.cancellationToken)
       .catch((e) => {
         sendSystemMessage(this.workerId, `An error occurred: ${e}`).catch((e) => console.log(e));
         console.log(e);
       })
       .finally(() => {
+        session.isFinished = true;
         restartKillTimer(this.workerId, restartToken);
       });
   }
 
-  public startResume() {
-    const session = { isFinished: false, cancellationToken: new CancellationToken() };
+  private _startResume() {
+    const session = { promise: Promise.resolve(), isFinished: false, cancellationToken: new CancellationToken() };
     this.sessions.push(session);
     const restartToken = pauseKillTimer();
-    resume(this.workerId, session.cancellationToken)
-      .then(() => {
-        session.isFinished = true;
-      })
+    session.promise = resume(this.workerId, session.cancellationToken)
       .catch((e) => {
         sendSystemMessage(this.workerId, `An error occurred: ${e}`).catch((e) => console.log(e));
         console.log(e);
       })
       .finally(() => {
+        session.isFinished = true;
         restartKillTimer(this.workerId, restartToken);
       });
   }
@@ -83,12 +106,20 @@ class ConverseSessionTracker {
    *
    * @param callback The callback function that is executed when each session is cancelled.
    */
-  public cancelCurrentSessions(callback?: () => Promise<any>) {
+  private async cancelCurrentSessions(callback?: () => Promise<any>) {
+    const runningPromises: Promise<void>[] = [];
     // cancel unfinished sessions
     for (const task of this.sessions) {
       if (task.isFinished) continue;
       task.cancellationToken.cancel(callback);
+      runningPromises.push(task.promise);
       console.log(`cancelled an ongoing converse session.`);
+    }
+    // await all running loops to fully stop before returning
+    if (runningPromises.length > 0) {
+      console.log(`Awaiting ${runningPromises.length} running session(s) to complete...`);
+      await Promise.allSettled(runningPromises);
+      console.log(`All sessions settled.`);
     }
     // remove finished sessions
     for (let i = this.sessions.length - 1; i >= 0; i--) {
@@ -135,10 +166,9 @@ export const main = async (workerId: string) => {
       }
       const type = event.type;
       if (type == 'onMessageReceived') {
-        tracker.cancelCurrentSessions();
         tracker.startOnMessageReceived();
       } else if (type == 'forceStop') {
-        tracker.cancelCurrentSessions(async () => {
+        tracker.forceStop(async () => {
           // Update agent status to pending after force stop
           await updateAgentStatusWithEvent(workerId, 'pending');
           await sendSystemMessage(workerId, 'Agent work was stopped.');


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add multi-agent communication capabilities with parent-child session grouping,
enabling agents to collaborate on complex tasks.

Motivation: Complex tasks benefit from dividing work across specialized agents.
A PM agent can spawn developer, reviewer, and tester agents as child sessions,
coordinate their work, and aggregate results - all within a single conversation
thread visible to the user.

Key capabilities:
- createNewSession: Agents create child/independent sessions with custom agents
- sendMessageToAgent: Send messages to other agents (wakes them up)
- acknowledgeAgent: Send read receipts without waking the target
- confirmSendToUser: Child sessions require parent confirmation before messaging
  the user directly, preventing notification spam
- Session hierarchy visible in sidebar with auto-expand and working indicators
- Agent-to-agent messages displayed with directional arrows
- ConverseSessionTracker prevents parallel agent loops from concurrent events
- Proper force-report timer reset for inter-agent communication tools

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
