### PR TITLE
feat: add server-side Mermaid diagram validator with self-heal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -112,6 +112,25 @@
         "node": ">=18"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
     "node_modules/@aws-amplify/adapter-nextjs": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@aws-amplify/adapter-nextjs/-/adapter-nextjs-1.7.1.tgz",
@@ -5037,6 +5056,116 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
       "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
@@ -10436,6 +10565,18 @@
       "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
       "license": "MIT"
     },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -10558,6 +10699,13 @@
         "@types/http-errors": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -12291,6 +12439,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -12815,6 +12976,19 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -13129,6 +13303,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -14733,6 +14919,18 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -14770,6 +14968,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -15304,6 +15515,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -15555,6 +15772,45 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -17927,6 +18183,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -18268,6 +18530,18 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -18588,7 +18862,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -19088,6 +19361,12 @@
         "node": ">= 18"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -19207,6 +19486,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -19813,6 +20104,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
@@ -19936,6 +20233,24 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -19964,6 +20279,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/trim-lines": {
@@ -21816,6 +22155,18 @@
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-push": {
       "version": "3.6.7",
       "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
@@ -21838,6 +22189,62 @@
     "node_modules/webapp": {
       "resolved": "packages/webapp",
       "link": true
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -22001,6 +22408,21 @@
         }
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -22095,11 +22517,14 @@
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@octokit/rest": "^22.0.0",
         "@slack/bolt": "^4.2.0",
+        "jsdom": "^26.1.0",
+        "mermaid": "^11.4.0",
         "p-retry": "^6.2.1",
         "sharp": "^0.33.5",
         "web-push": "^3.6.7"
       },
       "devDependencies": {
+        "@types/jsdom": "^21.1.7",
         "@types/node": "^22.13.1",
         "@types/web-push": "^3.6.4",
         "typescript": "^5.7.3",

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -44,14 +44,17 @@
     "@slack/bolt": "^4.2.0",
     "p-retry": "^6.2.1",
     "sharp": "^0.33.5",
-    "web-push": "^3.6.7"
+    "web-push": "^3.6.7",
+    "jsdom": "^26.1.0",
+    "mermaid": "^11.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.13.1",
     "@types/web-push": "^3.6.4",
     "typescript": "^5.7.3",
     "vitest": "^3.1.1",
-    "zod": "^4.0.0"
+    "zod": "^4.0.0",
+    "@types/jsdom": "^21.1.7"
   },
   "peerDependencies": {
     "zod": "^4.0.0"

--- a/packages/agent-core/src/lib/index.ts
+++ b/packages/agent-core/src/lib/index.ts
@@ -17,5 +17,6 @@ export * from './images';
 export * from './webapp-origin';
 export * from './preferences';
 export * from './custom-agent';
+export * from './mermaid-validator';
 export * from './push-notification';
 export * from './unread';

--- a/packages/agent-core/src/lib/mermaid-validator.test.ts
+++ b/packages/agent-core/src/lib/mermaid-validator.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from 'vitest';
+import { validateMermaidInText, buildMermaidFeedback } from './mermaid-validator';
+
+describe('validateMermaidInText', () => {
+  test('returns valid when no mermaid blocks present', async () => {
+    const result = await validateMermaidInText('Hello world, no diagrams here.');
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test('returns valid for correct flowchart', async () => {
+    const text = `Here is a diagram:
+\`\`\`mermaid
+graph TD
+    A[Start] --> B[End]
+\`\`\`
+Done.`;
+    const result = await validateMermaidInText(text);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test('returns valid for correct sequence diagram', async () => {
+    const text = `\`\`\`mermaid
+sequenceDiagram
+    Alice->>Bob: Hello
+    Bob-->>Alice: Hi
+\`\`\``;
+    const result = await validateMermaidInText(text);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test('returns invalid for broken syntax', async () => {
+    const text = `\`\`\`mermaid
+graph TD
+    A --> B
+    C --> invalid syntax here %%%
+    D[
+\`\`\``;
+    const result = await validateMermaidInText(text);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  test('returns invalid when one of multiple blocks is broken', async () => {
+    const text = `Valid:
+\`\`\`mermaid
+graph TD
+    A --> B
+\`\`\`
+
+Broken:
+\`\`\`mermaid
+sequenceDiagram
+    Alice->Bob Hello
+    invalid %%% syntax
+\`\`\``;
+    const result = await validateMermaidInText(text);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  test('ignores non-mermaid code blocks', async () => {
+    const text = `\`\`\`javascript
+const x = 1;
+\`\`\`
+
+\`\`\`python
+print("hello")
+\`\`\``;
+    const result = await validateMermaidInText(text);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test('ignores unclosed mermaid fences (partial/streaming)', async () => {
+    const text = `\`\`\`mermaid
+graph TD
+    A --> B`;
+    const result = await validateMermaidInText(text);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+});
+
+describe('buildMermaidFeedback', () => {
+  test('produces feedback string with error details', () => {
+    const errors = [{ chart: 'graph TD\n    A --> invalid', message: 'Parse error on line 2' }];
+    const feedback = buildMermaidFeedback(errors);
+    expect(feedback).toContain('[SYSTEM]');
+    expect(feedback).toContain('invalid Mermaid diagram syntax');
+    expect(feedback).toContain('1 diagram(s) failed validation');
+    expect(feedback).toContain('Parse error on line 2');
+    expect(feedback).toContain('A --> invalid');
+  });
+
+  test('handles multiple errors', () => {
+    const errors = [
+      { chart: 'graph TD\n    broken1', message: 'Error 1' },
+      { chart: 'sequenceDiagram\n    broken2', message: 'Error 2' },
+    ];
+    const feedback = buildMermaidFeedback(errors);
+    expect(feedback).toContain('2 diagram(s) failed validation');
+    expect(feedback).toContain('Diagram 1');
+    expect(feedback).toContain('Diagram 2');
+  });
+});

--- a/packages/agent-core/src/lib/mermaid-validator.ts
+++ b/packages/agent-core/src/lib/mermaid-validator.ts
@@ -1,0 +1,109 @@
+/**
+ * Server-side Mermaid diagram validator.
+ *
+ * Extracts fenced mermaid code blocks from assistant text and validates
+ * them using the mermaid library with a jsdom-backed DOM environment.
+ * Used by the orchestrator to detect broken diagrams before they reach
+ * the user, enabling LLM retry.
+ */
+
+const MERMAID_FENCE_RE = /```mermaid\s*\n([\s\S]*?)```/gi;
+
+/** Lazily-initialised mermaid instance (singleton). */
+let mermaidInstance: { parse: (text: string) => Promise<unknown> } | undefined;
+
+/**
+ * Initialise the jsdom + mermaid environment once per process. Subsequent
+ * calls return the cached instance. Uses dynamic import so the heavy deps
+ * are only loaded when mermaid validation is actually needed.
+ */
+const getMermaid = async (): Promise<{ parse: (text: string) => Promise<unknown> }> => {
+  if (mermaidInstance) return mermaidInstance;
+
+  const { JSDOM } = await import('jsdom');
+  const dom = new JSDOM('<!doctype html><html><body></body></html>');
+  (globalThis as any).window = dom.window;
+  (globalThis as any).document = dom.window.document;
+  try {
+    (globalThis as any).navigator = dom.window.navigator;
+  } catch {
+    Object.defineProperty(globalThis, 'navigator', {
+      value: dom.window.navigator,
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  const mermaid = (await import('mermaid')).default;
+  mermaid.initialize({ startOnLoad: false, securityLevel: 'loose' });
+
+  mermaidInstance = mermaid;
+  return mermaidInstance;
+};
+
+export interface MermaidValidationError {
+  /** The chart source that failed validation. */
+  chart: string;
+  /** Error message from the parser. */
+  message: string;
+}
+
+export interface MermaidValidationResult {
+  /** True when all mermaid blocks (if any) are syntactically valid. */
+  valid: boolean;
+  /** Details for each block that failed. Empty when valid. */
+  errors: MermaidValidationError[];
+}
+
+/**
+ * Extract closed mermaid fenced code blocks from `text` and validate each
+ * one. Returns `{ valid: true, errors: [] }` when there are no mermaid
+ * blocks or all blocks parse successfully.
+ */
+export const validateMermaidInText = async (text: string): Promise<MermaidValidationResult> => {
+  const charts: string[] = [];
+  let match: RegExpExecArray | null;
+  const re = new RegExp(MERMAID_FENCE_RE.source, MERMAID_FENCE_RE.flags);
+  while ((match = re.exec(text)) !== null) {
+    charts.push(match[1].trim());
+  }
+
+  if (charts.length === 0) {
+    return { valid: true, errors: [] };
+  }
+
+  const mermaid = await getMermaid();
+  const errors: MermaidValidationError[] = [];
+
+  for (const chart of charts) {
+    try {
+      const result = await mermaid.parse(chart);
+      if (result === false) {
+        errors.push({ chart, message: 'parse() returned false' });
+      }
+    } catch (e) {
+      errors.push({ chart, message: e instanceof Error ? e.message : String(e) });
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+};
+
+/**
+ * Build a concise LLM-facing feedback string describing which mermaid
+ * blocks failed and why. Used as the content of the retry feedback message.
+ */
+export const buildMermaidFeedback = (errors: MermaidValidationError[]): string => {
+  const lines = [
+    '[SYSTEM] Your previous response contained invalid Mermaid diagram syntax. Please regenerate your response with corrected Mermaid diagrams.',
+    '',
+    `${errors.length} diagram(s) failed validation:`,
+  ];
+  for (let i = 0; i < errors.length; i++) {
+    lines.push(`--- Diagram ${i + 1} ---`);
+    lines.push(`Error: ${errors[i].message}`);
+    lines.push(`Source:\n\`\`\`\n${errors[i].chart}\n\`\`\``);
+  }
+  lines.push('', 'Please fix the Mermaid syntax errors and regenerate your complete response.');
+  return lines.join('\n');
+};

--- a/packages/webapp/src/app/sessions/[workerId]/component/MermaidDiagram.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MermaidDiagram.tsx
@@ -61,10 +61,20 @@ export const MermaidDiagram = React.memo(function MermaidDiagram({ chart }: Merm
   }, [chart, mermaidTheme, uniqueId]);
 
   if (error) {
+    // `react-markdown` wraps fenced code blocks in a default `<pre>` whose
+    // browser-default `white-space: pre` is inherited by every descendant.
+    // Without `whitespace-normal` here, the error `<p>` below would refuse
+    // to wrap on long lines and blow past the chat bubble's `max-width`,
+    // producing a page-level horizontal scroll on mobile. `max-w-full`
+    // on the outer container plus `break-words` on the message and
+    // `overflow-x-auto` on the chart `<pre>` keep the rendering inside
+    // the bubble (chart scrolls internally when the diagram source is
+    // wider than the bubble), matching the existing code-block / table
+    // overflow pattern in `MarkdownRenderer`.
     return (
-      <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md p-4 mb-2">
-        <p className="text-red-600 dark:text-red-400 text-sm">Mermaid diagram error: {error}</p>
-        <pre className="text-xs mt-2 text-gray-600 dark:text-gray-400 overflow-x-auto">{chart}</pre>
+      <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-md p-4 mb-2 max-w-full whitespace-normal">
+        <p className="text-red-600 dark:text-red-400 text-sm break-words">Mermaid diagram error: {error}</p>
+        <pre className="text-xs mt-2 text-gray-600 dark:text-gray-400 overflow-x-auto max-w-full">{chart}</pre>
       </div>
     );
   }


### PR DESCRIPTION
## Summary

Adds a `mermaid-validator` library that extracts fenced mermaid code blocks from assistant text and validates them using the Mermaid parser with a jsdom-backed DOM environment, enabling LLM retry on syntax errors.

## Motivation

LLM-generated Mermaid diagrams occasionally contain syntax errors that cause rendering failures in the client. Server-side validation enables early detection and self-heal loops (ask the LLM to fix the diagram) without requiring a user round-trip.

## Changes

- `packages/agent-core/src/lib/mermaid-validator.ts` — Validator:
  - Extracts fenced mermaid blocks from text
  - Validates using mermaid's parse API in a jsdom environment
  - Returns structured errors with line info for LLM context
- `packages/agent-core/src/lib/mermaid-validator.test.ts` — Unit tests (108 lines)
- `packages/agent-core/src/lib/index.ts` — Re-export
- `packages/agent-core/package.json` — Added mermaid + jsdom dependencies
- `packages/webapp/.../MermaidDiagram.tsx` — Improved error UI with proper whitespace handling (prevents horizontal overflow on mobile)
- `package-lock.json` — Lockfile updates

**6 files changed, +663 −7**

## Testing

- Unit tests cover: valid diagram pass-through, syntax error detection, multi-block extraction, empty/missing blocks
- TypeScript compilation passes (`npm run build`)

## Notes

This change is self-contained with no dependencies on other pending PRs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
