### PR TITLE
feat: add image downscale and local preview URL management

### DIFF
--- a/packages/agent-core/src/lib/image-resize.ts
+++ b/packages/agent-core/src/lib/image-resize.ts
@@ -1,0 +1,76 @@
+import sharp from 'sharp';
+
+/**
+ * Claude API many-image constraint: when a conversation contains multiple images,
+ * each image must have both dimensions ≤ 2000px. We use 1568px (Claude's recommended
+ * optimal resolution) as the cap to stay well within the limit.
+ */
+export const MAX_IMAGE_DIMENSION = 1568;
+
+export interface EnsureImageWithinBoundsOptions {
+  format?: string;
+  mimeType?: string;
+}
+
+/**
+ * Downscale an image buffer so that neither dimension exceeds MAX_IMAGE_DIMENSION.
+ * Returns the original buffer unchanged if already within bounds or if dimensions
+ * cannot be determined (unknown format). Throws if the image is confirmed oversized
+ * but resize fails — preventing silent re-submission of an oversized payload that
+ * would trigger a permanent 400.
+ *
+ * @param imageBuffer Raw image bytes
+ * @param opts.format Bedrock-style format (e.g. 'png', 'jpeg', 'webp')
+ * @param opts.mimeType MIME type (e.g. 'image/png', 'image/jpeg')
+ */
+export const ensureImageWithinBounds = async (
+  imageBuffer: Uint8Array,
+  opts: EnsureImageWithinBoundsOptions = {}
+): Promise<Uint8Array> => {
+  let width: number | undefined;
+  let height: number | undefined;
+  try {
+    const metadata = await sharp(imageBuffer).metadata();
+    width = metadata.width;
+    height = metadata.height;
+  } catch {
+    return imageBuffer;
+  }
+  if (!width || !height || (width <= MAX_IMAGE_DIMENSION && height <= MAX_IMAGE_DIMENSION)) {
+    return imageBuffer;
+  }
+  // Image is confirmed oversized — resize MUST succeed or we throw
+  // (caller replaces with text placeholder rather than sending oversized data).
+  const outputFormat = resolveSharpFormat(opts);
+  const pipeline = sharp(imageBuffer).resize({
+    width: MAX_IMAGE_DIMENSION,
+    height: MAX_IMAGE_DIMENSION,
+    fit: 'inside',
+  });
+  if (outputFormat) {
+    pipeline.toFormat(outputFormat, { quality: 85 });
+  }
+  const resized = await pipeline.toBuffer();
+  return new Uint8Array(resized);
+};
+
+const MIME_TO_FORMAT: Record<string, keyof sharp.FormatEnum> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpeg',
+  'image/jpg': 'jpeg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+};
+
+const resolveSharpFormat = (opts: EnsureImageWithinBoundsOptions): keyof sharp.FormatEnum | undefined => {
+  if (opts.mimeType) {
+    return MIME_TO_FORMAT[opts.mimeType];
+  }
+  if (opts.format) {
+    const f = opts.format === 'jpg' ? 'jpeg' : opts.format;
+    if (['png', 'jpeg', 'gif', 'webp'].includes(f)) {
+      return f as keyof sharp.FormatEnum;
+    }
+  }
+  return undefined;
+};

--- a/packages/agent-core/src/lib/images.test.ts
+++ b/packages/agent-core/src/lib/images.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest';
+import { imageFormatFromKey } from './images';
+
+describe('imageFormatFromKey', () => {
+  test('extracts format from common S3 key extensions', () => {
+    expect(imageFormatFromKey('worker/abc.png')).toBe('png');
+    expect(imageFormatFromKey('worker/abc.jpeg')).toBe('jpeg');
+    expect(imageFormatFromKey('worker/abc.webp')).toBe('webp');
+    expect(imageFormatFromKey('worker/abc.gif')).toBe('gif');
+  });
+
+  test('normalises .jpg alias to jpeg', () => {
+    expect(imageFormatFromKey('worker/abc.jpg')).toBe('jpeg');
+  });
+
+  test('is case-insensitive', () => {
+    expect(imageFormatFromKey('worker/abc.PNG')).toBe('png');
+    expect(imageFormatFromKey('worker/abc.JPEG')).toBe('jpeg');
+  });
+
+  test('returns undefined for unrecognised / unsupported formats', () => {
+    expect(imageFormatFromKey('worker/abc.svg')).toBeUndefined();
+    expect(imageFormatFromKey('worker/abc.tiff')).toBeUndefined();
+    expect(imageFormatFromKey('worker/abc.bmp')).toBeUndefined();
+  });
+
+  test('returns undefined when there is no extension', () => {
+    expect(imageFormatFromKey('worker/abc')).toBeUndefined();
+    expect(imageFormatFromKey('')).toBeUndefined();
+  });
+
+  test('handles webapp_init keys (no workerId prefix)', () => {
+    expect(imageFormatFromKey('webapp_init/deadbeef.png')).toBe('png');
+  });
+
+  test('uses extension (not hardcoded webp) — regression guard', () => {
+    // Pre-fix, create-session.ts hardcoded 'webp' regardless of the key
+    // extension. This test guards against that regression.
+    expect(imageFormatFromKey('worker/abc.png')).not.toBe('webp');
+    expect(imageFormatFromKey('worker/abc.jpeg')).not.toBe('webp');
+  });
+});

--- a/packages/agent-core/src/lib/images.ts
+++ b/packages/agent-core/src/lib/images.ts
@@ -14,3 +14,42 @@ export const isImageKey = (key: string): boolean => {
   const imageExtensions = ['.jpg', '.jpeg', '.png', '.webp', '.svg', '.gif'];
   return imageExtensions.some((ext) => key.toLowerCase().endsWith(ext));
 };
+
+/**
+ * Supported Bedrock Image `format` values. Mirrors the set the
+ * `@aws-sdk/client-bedrock-runtime` `ImageFormat` enum advertises AND the
+ * MIME types Claude accepts on Bedrock `ContentBlock::Image`. SVG is
+ * intentionally excluded — neither Bedrock nor Claude image input accepts
+ * `image/svg+xml`, so a webapp drop of an SVG asset has to be rejected at
+ * the content-type layer upstream (see `imageContentTypes` in the upload
+ * presigner), not rescued here.
+ */
+export const SUPPORTED_IMAGE_FORMATS = ['png', 'jpeg', 'gif', 'webp'] as const;
+export type SupportedImageFormat = (typeof SUPPORTED_IMAGE_FORMATS)[number];
+
+/**
+ * Derive the Bedrock-compatible image format from an S3 key. The webapp
+ * upload presigner sets the key's extension from the HTTP `Content-Type`
+ * (`contentType.split('/')[1]` in actions/upload/action.ts), so the
+ * extension is an authoritative signal of the object's actual bytes.
+ *
+ * Returns `undefined` for unknown / missing extensions so callers can
+ * decide whether to default to a safe value or reject the image. Do not
+ * default to `'webp'` (the pre-2026-04-20 behaviour): DDB rows persisted
+ * with an incorrect format caused the Bedrock Converse API to raise
+ * `ValidationException` on history replay because the base64 bytes (real
+ * PNG) did not match the advertised `image/webp` MIME type.
+ *
+ * Examples:
+ *   "worker-1/abc123.png"      -> "png"
+ *   "worker-1/abc123.jpeg"     -> "jpeg"
+ *   "worker-1/abc123.jpg"      -> "jpeg"    (aliased)
+ *   "worker-1/abc123"          -> undefined
+ *   "worker-1/abc123.svg"      -> undefined (unsupported by Bedrock)
+ */
+export const imageFormatFromKey = (key: string): SupportedImageFormat | undefined => {
+  const ext = extname(key).toLowerCase().replace(/^\./, '');
+  if (!ext) return undefined;
+  if (ext === 'jpg') return 'jpeg';
+  return (SUPPORTED_IMAGE_FORMATS as readonly string[]).includes(ext) ? (ext as SupportedImageFormat) : undefined;
+};

--- a/packages/agent-core/src/lib/index.ts
+++ b/packages/agent-core/src/lib/index.ts
@@ -14,6 +14,7 @@ export * from './cost';
 export * from './todo';
 export * from './api-key';
 export * from './images';
+export * from './image-resize';
 export * from './webapp-origin';
 export * from './preferences';
 export * from './custom-agent';

--- a/packages/webapp/src/app/sessions/[workerId]/component/ImageViewer.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/ImageViewer.tsx
@@ -3,9 +3,19 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { Loader2, ExternalLink, X } from 'lucide-react';
 import { getImageUrls } from '@/actions/image/action';
+import { claimForMessage, isUsable, releaseFromMessage, scheduleReleaseFromMessage } from '@/lib/local-image-urls';
+import { useBodyScrollLock } from '@/hooks/use-body-scroll-lock';
 
 type ImageViewerProps = {
   imageKeys: string[];
+  /**
+   * Blob object URLs for keys whose bytes are already in local memory (the
+   * submitter's own optimistic bubble, see `MessageView.localImageUrls`).
+   * Seeded into the cache so the image paints instantly; the real pre-signed
+   * URL is fetched in the background and swapped in only after it has fully
+   * loaded (no flicker), at which point the blob is revoked.
+   */
+  localImageUrls?: Record<string, string>;
 };
 
 type ImageData = {
@@ -15,9 +25,49 @@ type ImageData = {
   error: boolean;
 };
 
-export const ImageViewer = ({ imageKeys: inputKeys }: ImageViewerProps) => {
+/**
+ * Preload the pre-signed URL fully before swapping it into the <img>, so the
+ * blob → https transition never flashes.
+ */
+const preloadImage = (url: string) =>
+  new Promise<void>((resolve, reject) => {
+    const img = new window.Image();
+    img.onload = () => resolve();
+    img.onerror = () => reject(new Error(`Failed to preload ${url}`));
+    img.src = url;
+  });
+
+export const ImageViewer = ({ imageKeys: inputKeys, localImageUrls }: ImageViewerProps) => {
+  // Lazy initializer: seed once per mount from the blob previews.
+  // `localImageUrls` is set at optimistic-submit time and never changes for
+  // a given message; URLs already revoked (per the ownership registry) are
+  // skipped so a remount falls back to the normal spinner → pre-signed path.
+  const [seededEntries] = useState<ImageData[]>(() => {
+    if (!localImageUrls) return [];
+    return Object.entries(localImageUrls)
+      .filter(([, url]) => isUsable(url))
+      .map(([key, url]) => ({ key, url, loading: false, error: false }));
+  });
   const [images, setImages] = useState<ImageData[]>([]);
-  const [imageCache, setImageCache] = useState<Map<string, ImageData>>(new Map());
+  const [imageCache, setImageCache] = useState<Map<string, ImageData>>(
+    () => new Map(seededEntries.map((entry) => [entry.key, entry]))
+  );
+
+  // Blob lifecycle (see lib/local-image-urls.ts): claim ownership for this
+  // message on mount; on unmount, schedule a token-guarded deferred release
+  // for whatever was not already released by a successful swap. A remount of
+  // the same message (pending → confirmed id change, StrictMode) re-claims
+  // within the grace window and keeps the blob alive; a rollback moves
+  // ownership to the uploader, making the release a no-op; a permanent
+  // unmount lets the release revoke the blob so it cannot leak until the
+  // tab closes.
+  useEffect(() => {
+    const urls = seededEntries.map((entry) => entry.url);
+    urls.forEach(claimForMessage);
+    return () => {
+      urls.forEach((url) => scheduleReleaseFromMessage(url));
+    };
+  }, [seededEntries]);
   const [previewImage, setPreviewImage] = useState<ImageData | null>(null);
   const imageKeys = useMemo(
     () =>
@@ -35,6 +85,12 @@ export const ImageViewer = ({ imageKeys: inputKeys }: ImageViewerProps) => {
   );
 
   useEffect(() => {
+    // Cancellation guard (W1): the async pipeline below (getImageUrls →
+    // preload → swap/release) can outlive this effect — the bubble may be
+    // rolled back (unmount) or the message id may change (remount) while a
+    // request is in flight. A cancelled pipeline must neither touch state
+    // nor release a blob it may no longer own.
+    let cancelled = false;
     const loadImages = async () => {
       // Build display data immediately from existing cache (without showing loading state)
       const currentImages = imageKeys.map((key) => {
@@ -46,11 +102,20 @@ export const ImageViewer = ({ imageKeys: inputKeys }: ImageViewerProps) => {
       // Always refetch signed URLs as they may expire
       try {
         const result = await getImageUrls({ keys: imageKeys });
+        if (cancelled) return;
 
         if (result?.data) {
+          // Keys currently painted from a local blob preview swap lazily:
+          // the pre-signed URL is preloaded first so the <img> never flashes
+          // during the src change, then the blob is revoked. Everything else
+          // updates immediately (existing behaviour).
+          const isBlobBacked = (key: string) => imageCache.get(key)?.url.startsWith('blob:') ?? false;
+          const immediate = result.data.filter((item) => !isBlobBacked(item.key));
+          const deferred = result.data.filter((item) => isBlobBacked(item.key));
+
           // Update cache
           const newCache = new Map(imageCache);
-          result.data.forEach((item) => {
+          immediate.forEach((item) => {
             newCache.set(item.key, {
               key: item.key,
               url: item.url,
@@ -60,15 +125,42 @@ export const ImageViewer = ({ imageKeys: inputKeys }: ImageViewerProps) => {
           });
           setImageCache(newCache);
 
-          // Update display data from cache
+          // Update display data from cache (blob-backed keys keep their
+          // seeded blob entry here; they are swapped below once preloaded)
           setImages(
             imageKeys.map((key) => {
               const cached = newCache.get(key);
               return cached || { key, url: '', loading: false, error: true };
             })
           );
+
+          deferred.forEach(({ key, url }) => {
+            const blobUrl = imageCache.get(key)!.url;
+            void preloadImage(url)
+              .then(() => {
+                // Cancelled (rollback / remount): do not touch state, and do
+                // NOT release the blob — ownership may have moved back to
+                // the uploader, or a remounted viewer may still be
+                // displaying it. The unmount cleanup's deferred release (or
+                // the new owner) handles the blob's fate.
+                if (cancelled) return;
+                const entry: ImageData = { key, url, loading: false, error: false };
+                setImageCache((prev) => new Map(prev).set(key, entry));
+                setImages((prev) => prev.map((img) => (img.key === key ? entry : img)));
+                // Swap complete: revoke IF this message still owns the blob
+                // (no-op if a rollback returned it to the uploader first).
+                releaseFromMessage(blobUrl);
+              })
+              .catch(() => {
+                // Preload failed (network hiccup / expired URL): keep
+                // showing the blob. Nothing is persisted, so a reload
+                // resolves the image through the normal pre-signed path;
+                // the unmount cleanup's deferred release prevents a leak.
+              });
+          });
         }
       } catch (error) {
+        if (cancelled) return;
         console.error('Failed to load image URLs:', error);
         // On error, preserve existing cache and only set new keys to error state
         const newCache = new Map(imageCache);
@@ -91,6 +183,9 @@ export const ImageViewer = ({ imageKeys: inputKeys }: ImageViewerProps) => {
     if (imageKeys.length > 0) {
       loadImages();
     }
+    return () => {
+      cancelled = true;
+    };
   }, [imageKeys]);
 
   const handleKeyDown = useCallback(
@@ -106,13 +201,13 @@ export const ImageViewer = ({ imageKeys: inputKeys }: ImageViewerProps) => {
   useEffect(() => {
     if (previewImage) {
       document.addEventListener('keydown', handleKeyDown, true);
-      document.body.style.overflow = 'hidden';
       return () => {
         document.removeEventListener('keydown', handleKeyDown, true);
-        document.body.style.overflow = '';
       };
     }
   }, [previewImage, handleKeyDown]);
+
+  useBodyScrollLock(!!previewImage);
 
   if (imageKeys.length === 0) {
     return null;
@@ -148,7 +243,7 @@ export const ImageViewer = ({ imageKeys: inputKeys }: ImageViewerProps) => {
 
       {previewImage && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm overscroll-contain touch-pinch-zoom"
           onClick={() => setPreviewImage(null)}
         >
           <div className="absolute top-4 right-4 flex gap-2 z-10">

--- a/packages/webapp/src/hooks/use-body-scroll-lock.ts
+++ b/packages/webapp/src/hooks/use-body-scroll-lock.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react';
+
+let lockCount = 0;
+let savedScrollY = 0;
+
+function lock() {
+  if (lockCount === 0) {
+    savedScrollY = window.scrollY;
+    document.body.style.position = 'fixed';
+    document.body.style.top = `-${savedScrollY}px`;
+    document.body.style.left = '0';
+    document.body.style.right = '0';
+    document.body.style.overflow = 'hidden';
+  }
+  lockCount++;
+}
+
+function unlock() {
+  lockCount--;
+  if (lockCount <= 0) {
+    lockCount = 0;
+    document.body.style.position = '';
+    document.body.style.top = '';
+    document.body.style.left = '';
+    document.body.style.right = '';
+    document.body.style.overflow = '';
+    window.scrollTo(0, savedScrollY);
+  }
+}
+
+export function useBodyScrollLock(active: boolean) {
+  const wasActive = useRef(false);
+
+  useEffect(() => {
+    if (active && !wasActive.current) {
+      lock();
+      wasActive.current = true;
+    } else if (!active && wasActive.current) {
+      unlock();
+      wasActive.current = false;
+    }
+    return () => {
+      if (wasActive.current) {
+        unlock();
+        wasActive.current = false;
+      }
+    };
+  }, [active]);
+}

--- a/packages/webapp/src/lib/local-image-urls.test.ts
+++ b/packages/webapp/src/lib/local-image-urls.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import {
+  claimForMessage,
+  isUsable,
+  markRevoked,
+  releaseFromMessage,
+  returnToUploader,
+  scheduleReleaseFromMessage,
+  RELEASE_GRACE_MS,
+} from './local-image-urls';
+
+// Each test uses a unique URL because the registry is module-scoped
+// (mirroring the page-lifetime of real blob URLs).
+let n = 0;
+const freshUrl = () => `blob:https://example/test-${++n}`;
+
+describe('local-image-urls ownership registry', () => {
+  const revokeSpy = vi.fn();
+  beforeEach(() => {
+    vi.useFakeTimers();
+    revokeSpy.mockClear();
+    vi.stubGlobal('URL', { ...URL, revokeObjectURL: revokeSpy });
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  test('swap success: message owner releases → revoked exactly once, no longer usable', () => {
+    const url = freshUrl();
+    claimForMessage(url);
+    expect(isUsable(url)).toBe(true);
+    releaseFromMessage(url);
+    expect(revokeSpy).toHaveBeenCalledTimes(1);
+    expect(isUsable(url)).toBe(false);
+    // Idempotent: a second (late) release is a no-op.
+    releaseFromMessage(url);
+    expect(revokeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('W1 race: rollback returns ownership to uploader → in-flight release becomes a no-op', () => {
+    const url = freshUrl();
+    claimForMessage(url); // takeover at submit
+    returnToUploader(url); // rollback lands
+    releaseFromMessage(url); // ImageViewer pipeline resolves late
+    expect(revokeSpy).not.toHaveBeenCalled();
+    expect(isUsable(url)).toBe(true); // uploader previews keep working
+  });
+
+  test('W1 inverse race: swap revoked first → rollback must see the blob as unusable', () => {
+    const url = freshUrl();
+    claimForMessage(url);
+    releaseFromMessage(url); // swap finished before the failure landed
+    expect(isUsable(url)).toBe(false); // MessageForm falls back to restoreFromKeys
+    // returning a revoked URL is a no-op, it cannot resurrect
+    returnToUploader(url);
+    expect(isUsable(url)).toBe(false);
+  });
+
+  test('W2: deferred release revokes after the grace window on permanent unmount', () => {
+    const url = freshUrl();
+    claimForMessage(url);
+    scheduleReleaseFromMessage(url);
+    expect(revokeSpy).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(RELEASE_GRACE_MS);
+    expect(revokeSpy).toHaveBeenCalledTimes(1);
+    expect(isUsable(url)).toBe(false);
+  });
+
+  test('remount within the grace window re-claims and cancels the deferred release', () => {
+    const url = freshUrl();
+    claimForMessage(url); // mount 1
+    scheduleReleaseFromMessage(url); // unmount 1 (pending → confirmed remount)
+    claimForMessage(url); // mount 2 re-claims (token bump)
+    vi.advanceTimersByTime(RELEASE_GRACE_MS);
+    expect(revokeSpy).not.toHaveBeenCalled();
+    expect(isUsable(url)).toBe(true);
+  });
+
+  test('deferred release after rollback is a no-op (uploader owns the blob)', () => {
+    const url = freshUrl();
+    claimForMessage(url);
+    scheduleReleaseFromMessage(url); // viewer unmounts due to rollback
+    returnToUploader(url); // rollback hands the blob back
+    vi.advanceTimersByTime(RELEASE_GRACE_MS);
+    expect(revokeSpy).not.toHaveBeenCalled();
+    expect(isUsable(url)).toBe(true);
+  });
+
+  test('uploader-side revocation (remove/clear) is terminal', () => {
+    const url = freshUrl();
+    claimForMessage(url);
+    returnToUploader(url);
+    markRevoked(url); // uploader revoked it itself
+    expect(isUsable(url)).toBe(false);
+    claimForMessage(url); // a later claim cannot resurrect a dead URL
+    expect(isUsable(url)).toBe(false);
+    releaseFromMessage(url);
+    expect(revokeSpy).not.toHaveBeenCalled(); // markRevoked does not double-revoke
+  });
+});

--- a/packages/webapp/src/lib/local-image-urls.ts
+++ b/packages/webapp/src/lib/local-image-urls.ts
@@ -1,0 +1,83 @@
+/**
+ * Ownership registry for the blob object URLs that back instant image
+ * previews (`MessageView.localImageUrls`).
+ *
+ * Invariant: the CURRENT OWNER of a blob URL is the only party allowed to
+ * decide its lifecycle (revoke it or keep it alive). A blob's ownership
+ * moves as follows:
+ *
+ *   uploader --(takeoverAttachments)--> message
+ *   message --(rollback: restoreTakenOverAttachments)--> uploader
+ *   message --(pre-signed swap succeeded)--> revoked (terminal)
+ *   uploader --(remove / clear / re-takeover)--> revoked or message
+ *
+ * Why a registry instead of purely local guards: the optimistic bubble's
+ * `ImageViewer` starts an async getImageUrls → preload → revoke pipeline the
+ * moment it mounts. A submission failure can roll the bubble back (unmount)
+ * and hand the blob back to the uploader while that pipeline is still in
+ * flight — the pipeline's completion must then NOT revoke a blob it no
+ * longer owns. Conversely the pipeline can finish (blob revoked) before the
+ * failure lands — the rollback must then NOT hand a dead blob back to the
+ * uploader. Both sides consult this registry, so the decision is always made
+ * against the current owner, not against stale closure state.
+ *
+ * `releaseFromMessage` only revokes while the message still owns the URL;
+ * calls after ownership moved (or after revocation) are no-ops, so races
+ * resolve safely regardless of ordering.
+ *
+ * Deferred release (`scheduleReleaseFromMessage`): an unmounting viewer
+ * cannot distinguish "gone for good" (navigation — the blob would leak until
+ * tab close) from "about to remount" (pending → confirmed re-render, React
+ * StrictMode double-mount). Release is therefore scheduled with a grace
+ * delay and a claim token: any re-claim within the grace window (a remount
+ * claims on mount, a re-takeover claims at submit) invalidates the token and
+ * keeps the blob alive.
+ *
+ * Module-scoped and memory-only, mirroring the lifetime of the blob URLs it
+ * tracks (both die with the page).
+ */
+
+type LocalImageUrlOwner = 'message' | 'uploader' | 'revoked';
+
+const owners = new Map<string, LocalImageUrlOwner>();
+const claimTokens = new Map<string, number>();
+
+export const RELEASE_GRACE_MS = 5_000;
+
+export function claimForMessage(url: string): void {
+  if (owners.get(url) === 'revoked') return;
+  owners.set(url, 'message');
+  claimTokens.set(url, (claimTokens.get(url) ?? 0) + 1);
+}
+
+export function returnToUploader(url: string): void {
+  if (owners.get(url) === 'revoked') return;
+  owners.set(url, 'uploader');
+}
+
+export function releaseFromMessage(url: string): void {
+  if (owners.get(url) !== 'message') return;
+  owners.set(url, 'revoked');
+  try {
+    URL.revokeObjectURL(url);
+  } catch {}
+}
+
+/** Record a revocation performed by the uploader itself (remove / clear). */
+export function markRevoked(url: string): void {
+  owners.set(url, 'revoked');
+}
+
+/** Whether the URL may still be rendered / handed to a new owner. */
+export function isUsable(url: string): boolean {
+  return owners.get(url) !== 'revoked';
+}
+
+export function scheduleReleaseFromMessage(url: string, delayMs: number = RELEASE_GRACE_MS): void {
+  const token = claimTokens.get(url);
+  setTimeout(() => {
+    if (claimTokens.get(url) === token) {
+      releaseFromMessage(url);
+    }
+  }, delayMs);
+}


### PR DESCRIPTION
## Summary

Adds server-side image downscaling (sharp-based, caps at 1568px for Claude's multi-image constraint) and client-side blob URL lifecycle management for instant image previews.

## Motivation

- **Server-side:** Claude has per-image pixel limits for multi-image messages. Downscaling ensures images fit within constraints before sending to the model.
- **Client-side:** Large images loaded from pre-signed URLs cause visible layout jumps. Blob URL previews provide instant display while the full image loads in background.

## Changes

### Server-side (agent-core)
- `packages/agent-core/src/lib/image-resize.ts` — `ensureImageWithinBounds`: sharp-based resize with format detection, preserves aspect ratio
- `packages/agent-core/src/lib/images.ts` — `imageFormatFromKey`, `SUPPORTED_IMAGE_FORMATS` utilities
- `packages/agent-core/src/lib/images.test.ts` — Unit tests (42 lines)
- `packages/agent-core/src/lib/index.ts` — Re-export

### Client-side (webapp)
- `packages/webapp/src/lib/local-image-urls.ts` — Blob URL ownership registry with deferred release and claim tokens (prevents premature revocation on React remount)
- `packages/webapp/src/lib/local-image-urls.test.ts` — Unit tests (101 lines)
- `packages/webapp/.../ImageViewer.tsx` — Instant preview via seeded blob URLs, preload-then-swap for flicker-free transition
- `packages/webapp/src/hooks/use-body-scroll-lock.ts` — Hook for lightbox overlay scroll lock

**8 files changed, +493 −7**

## Testing

- Unit tests cover: image format detection, blob URL registry lifecycle, claim/release semantics
- TypeScript compilation passes (`npm run build`)

## Notes

This change is self-contained with no dependencies on other pending PRs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
