### PR TITLE
feat: add KaTeX math rendering support with scroll affordance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10600,6 +10600,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -14808,6 +14814,88 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-parse-selector": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
@@ -14815,6 +14903,30 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
       },
       "funding": {
         "type": "opencollective",
@@ -14842,6 +14954,22 @@
         "style-to-js": "^1.0.0",
         "unist-util-position": "^5.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -14939,6 +15067,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/http_ece": {
@@ -15966,9 +16105,9 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.45",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
-      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
@@ -16678,6 +16817,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-mdx-expression": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
@@ -17047,6 +17205,25 @@
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -19147,6 +19324,41 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-stringify": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
@@ -19158,6 +19370,22 @@
         "micromark-extension-gfm": "^3.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -21110,6 +21338,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
@@ -21130,6 +21372,20 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -21372,6 +21628,20 @@
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -22167,6 +22437,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/web-push": {
       "version": "3.6.7",
       "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
@@ -22601,6 +22881,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "katex": "^0.16.47",
         "lucide-react": "^0.488.0",
         "mermaid": "^11.14.0",
         "next": "^16.1.6",
@@ -22612,7 +22893,9 @@
         "react-hook-form": "^7.62.0",
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^16.1.0",
+        "rehype-katex": "^7.0.1",
         "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0",
         "sonner": "^2.0.3",
         "tailwind-merge": "^3.2.0",
         "tw-animate-css": "^1.2.5",
@@ -22629,8 +22912,12 @@
         "eslint": "^9",
         "eslint-config-next": "^16.1.6",
         "prettier": "^3.5.3",
+        "rehype-stringify": "^10.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "unified": "^11.0.5"
       }
     },
     "packages/webapp/node_modules/@types/node": {

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -48,7 +48,10 @@
     "sonner": "^2.0.3",
     "tailwind-merge": "^3.2.0",
     "tw-animate-css": "^1.2.5",
-    "zod": "^4.0.0"
+    "zod": "^4.0.0",
+    "katex": "^0.16.47",
+    "rehype-katex": "^7.0.1",
+    "remark-math": "^6.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -62,6 +65,10 @@
     "eslint-config-next": "^16.1.6",
     "prettier": "^3.5.3",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "rehype-stringify": "^10.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
+    "unified": "^11.0.5"
   }
 }

--- a/packages/webapp/src/app/globals.css
+++ b/packages/webapp/src/app/globals.css
@@ -1,5 +1,6 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
+@import 'katex/dist/katex.min.css';
 
 @custom-variant dark (&:is(.dark *));
 
@@ -118,6 +119,58 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+
+  .katex-display {
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  /* Scroll affordance for containers with overflowing math.
+     color mismatch issues). A useScrollOverflow hook sets data-overflowing,
+     data-at-start, data-at-end on the container; CSS drives the mask. */
+  .katex-scroll-container[data-overflowing='true'] {
+    mask-image: linear-gradient(to right, transparent, black 24px, black calc(100% - 24px), transparent);
+    -webkit-mask-image: linear-gradient(to right, transparent, black 24px, black calc(100% - 24px), transparent);
+  }
+  .katex-scroll-container[data-overflowing='true'][data-at-start='true'] {
+    mask-image: linear-gradient(to right, black 0%, black calc(100% - 24px), transparent);
+    -webkit-mask-image: linear-gradient(to right, black 0%, black calc(100% - 24px), transparent);
+  }
+  .katex-scroll-container[data-overflowing='true'][data-at-end='true'] {
+    mask-image: linear-gradient(to right, transparent, black 24px, black 100%);
+    -webkit-mask-image: linear-gradient(to right, transparent, black 24px, black 100%);
+  }
+  .katex-scroll-container[data-overflowing='true'][data-at-start='true'][data-at-end='true'] {
+    mask-image: none;
+    -webkit-mask-image: none;
+  }
+
+  /* Slim custom scrollbar for math containers. */
+  .katex-scroll-container {
+    overflow-y: clip;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
+  }
+  .dark .katex-scroll-container {
+    scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
+  }
+  .katex-scroll-container::-webkit-scrollbar {
+    height: 3px;
+  }
+  .katex-scroll-container::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .katex-scroll-container::-webkit-scrollbar-thumb {
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 3px;
+  }
+  .dark .katex-scroll-container::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.2);
+  }
+
+  .katex-display > .katex {
+    white-space: nowrap;
   }
 }
 

--- a/packages/webapp/src/app/globals.css
+++ b/packages/webapp/src/app/globals.css
@@ -127,6 +127,7 @@
   }
 
   /* Scroll affordance for containers with overflowing math.
+     Uses mask-image to fade edges (background-color independent — no cover
      color mismatch issues). A useScrollOverflow hook sets data-overflowing,
      data-at-start, data-at-end on the container; CSS drives the mask. */
   .katex-scroll-container[data-overflowing='true'] {
@@ -146,7 +147,11 @@
     -webkit-mask-image: none;
   }
 
-  /* Slim custom scrollbar for math containers. */
+  /* Slim custom scrollbar for math containers.
+     overflow-y: clip prevents vertical scrollbar — CSS spec computes
+     overflow-y to auto when overflow-x is auto, which can expose a
+     vertical scrollbar on tall KaTeX expressions. clip suppresses this
+     without creating a scroll mechanism. */
   .katex-scroll-container {
     overflow-y: clip;
     scrollbar-width: thin;
@@ -169,6 +174,10 @@
     background: rgba(255, 255, 255, 0.2);
   }
 
+  /* Defensive: duplicates katex.min.css declaration to guard against future
+     versions that might drop or weaken it. Note: if a future KaTeX upgrade
+     introduces higher-specificity rules for .katex-display > .katex, this
+     may create cascade conflicts — verify after upgrading. */
   .katex-display > .katex {
     white-space: nowrap;
   }

--- a/packages/webapp/src/app/sessions/[workerId]/component/KatexScrollContainer.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/KatexScrollContainer.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import React from 'react';
+import { useScrollOverflow } from '@/hooks/use-scroll-overflow';
+
+type KatexScrollContainerProps = {
+  tag: 'p' | 'li';
+  className?: string;
+  children: React.ReactNode;
+};
+
+export function KatexScrollContainer({ tag: Tag, className, children }: KatexScrollContainerProps) {
+  const ref = useScrollOverflow<HTMLElement>();
+  return (
+    <Tag
+      ref={ref as React.Ref<HTMLParagraphElement & HTMLLIElement>}
+      className={`${className ?? ''} overflow-x-auto katex-scroll-container`}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/packages/webapp/src/app/sessions/[workerId]/component/MarkdownRenderer.test.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MarkdownRenderer.test.tsx
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'vitest';
+import rehypeKatex from 'rehype-katex';
+import rehypeStringify from 'rehype-stringify';
+import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+import { unified } from 'unified';
+
+/**
+ * `MarkdownRenderer` (the React component) wires `react-markdown` with
+ * `remark-gfm` + `remark-math` + `[rehype-katex, { errorColor: 'currentColor' }]`.
+ * Internally that pipeline is just `unified().use(remarkParse).use(...)` —
+ * so we can pin the math behaviour we ship to users by running the same
+ * plugin chain at the unified level and asserting on the produced HTML.
+ *
+ * Why not render the React component? Vitest is configured with
+ * `environment: 'node'` for the rest of the webapp tests, and KaTeX itself
+ * is plain string→string; mounting via jsdom would only test React's
+ * pass-through behaviour, not the plugin pipeline. Keeping the test at the
+ * unified level matches the existing pure-function style (see
+ * `MessageList.test.ts`, `port-url-transform.test.ts`).
+ *
+ * If `MarkdownRenderer.tsx` ever changes its plugin set or options, this
+ * mirror MUST be updated to match — that's the whole point of a regression
+ * pin.
+ */
+const REHYPE_KATEX_OPTIONS = { errorColor: 'currentColor' } as const;
+
+function renderMarkdown(markdown: string): string {
+  return unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkMath)
+    .use(remarkRehype)
+    .use(rehypeKatex, REHYPE_KATEX_OPTIONS)
+    .use(rehypeStringify)
+    .processSync(markdown)
+    .toString();
+}
+
+describe('MarkdownRenderer math pipeline', () => {
+  test('inline math `$E=mc^2$` renders as a .katex span', () => {
+    const html = renderMarkdown('Inline: $E=mc^2$ here');
+    expect(html).toMatch(/class="katex"/);
+    // Block-display container must NOT appear for inline math.
+    expect(html).not.toMatch(/class="katex-display"/);
+    // KaTeX rewrites the source into MathML + HTML; presence of the
+    // <annotation encoding="application/x-tex"> with the original TeX is
+    // a stable signal across KaTeX versions.
+    expect(html).toContain('E=mc^2');
+  });
+
+  test('block math `$$...$$` renders as a .katex-display block', () => {
+    const html = renderMarkdown('$$\n\\sum_{i=1}^n i\n$$');
+    expect(html).toMatch(/class="katex-display"/);
+    expect(html).toContain('\\sum_{i=1}^n i');
+  });
+
+  test('two single-dollar tokens render as math (GitHub-compatible behaviour)', () => {
+    // Known caveat of `remark-math` defaults (`singleDollarTextMath: true`):
+    // a paragraph like `It costs $100 and saves $200` is parsed as
+    // `inlineMath("100 and saves ")` followed by trailing text. This matches
+    // GitHub / Pandoc / Jupyter behaviour — users who literally mean a
+    // dollar sign must escape it as `\$` (see escape tests below) or wrap
+    // the price in inline code (`` `$100` ``). We pin this behaviour here
+    // so that anyone disabling `singleDollarTextMath` in the future
+    // intentionally re-decides the trade-off.
+    const html = renderMarkdown('It costs $100 and saves $200');
+    expect(html).toMatch(/class="katex"/);
+    // The TeX source `100 and saves ` ends up inside KaTeX's MathML
+    // <annotation encoding="application/x-tex"> output — pinning the exact
+    // boundary makes a regression on the boundary visible.
+    expect(html).toContain('100 and saves');
+    // `200` falls outside the inline math span as trailing plain text.
+    expect(html).toContain('200');
+  });
+
+  test('inline code protects `$` from being parsed as math', () => {
+    const html = renderMarkdown('Use `$100` for the price');
+    // Should be a <code> element, never a math span.
+    expect(html).toContain('<code>$100</code>');
+    expect(html).not.toMatch(/class="katex"/);
+  });
+
+  test('escaped `\\$` is rendered as a literal dollar sign', () => {
+    const html = renderMarkdown('Cost: \\$100 only');
+    expect(html).not.toMatch(/class="katex"/);
+    expect(html).toContain('$100');
+  });
+
+  test('escaping every `$` neutralises the two-dollar math match', () => {
+    const html = renderMarkdown('Cost: \\$100 and \\$200 escaped');
+    expect(html).not.toMatch(/class="katex"/);
+    expect(html).toContain('$100');
+    expect(html).toContain('$200');
+  });
+
+  test('fenced code block content is not parsed as math', () => {
+    const html = renderMarkdown('```\nlet price = $100;\nlet total = $200;\n```');
+    expect(html).not.toMatch(/class="katex"/);
+    expect(html).toContain('$100');
+    expect(html).toContain('$200');
+  });
+});

--- a/packages/webapp/src/app/sessions/[workerId]/component/MarkdownRenderer.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MarkdownRenderer.tsx
@@ -9,6 +9,7 @@ import { useTheme } from 'next-themes';
 import type { PluggableList } from 'unified';
 import { MermaidDiagram } from './MermaidDiagram';
 import { KatexScrollContainer } from './KatexScrollContainer';
+import { escapePriceDollars } from '@/lib/escape-price-dollars';
 
 type MarkdownRendererProps = {
   content: string;
@@ -56,6 +57,8 @@ export const MarkdownRenderer = React.memo(function MarkdownRenderer({ content }
 
   const remarkPlugins = React.useMemo<PluggableList>(() => [remarkGfm, remarkMath], []);
   const rehypePlugins = React.useMemo<PluggableList>(() => [[rehypeKatex, REHYPE_KATEX_OPTIONS]], []);
+
+  const processedContent = React.useMemo(() => escapePriceDollars(content), [content]);
 
   return (
     <ReactMarkdown
@@ -159,7 +162,7 @@ export const MarkdownRenderer = React.memo(function MarkdownRenderer({ content }
         ),
       }}
     >
-      {content}
+      {processedContent}
     </ReactMarkdown>
   );
 });

--- a/packages/webapp/src/app/sessions/[workerId]/component/MarkdownRenderer.tsx
+++ b/packages/webapp/src/app/sessions/[workerId]/component/MarkdownRenderer.tsx
@@ -3,17 +3,50 @@ import ReactMarkdown from 'react-markdown';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
+import rehypeKatex from 'rehype-katex';
 import { useTheme } from 'next-themes';
+import type { PluggableList } from 'unified';
 import { MermaidDiagram } from './MermaidDiagram';
+import { KatexScrollContainer } from './KatexScrollContainer';
 
 type MarkdownRendererProps = {
   content: string;
 };
 
+// Render KaTeX parse errors in the surrounding text color (instead of the
+// default red) so that streaming partial block math like `$$\sum_{i=1}^n`
+// doesn't flash red on every new token. `trust` stays at its safe default
+// of false — never enable: it would allow user-controlled HTML/JS via
+// `\href` and similar primitives. Inline math `$...$` and block math
+// `$$...$$` use `remark-math`'s defaults (singleDollarTextMath: true) so
+// that GitHub-/Pandoc-/Jupyter-compatible syntax works out of the box.
+const REHYPE_KATEX_OPTIONS = {
+  errorColor: 'currentColor',
+} as const;
+
+function containsKatex(children: React.ReactNode): boolean {
+  return React.Children.toArray(children).some((child) => {
+    if (!React.isValidElement(child)) return false;
+    const props = child.props as Record<string, unknown>;
+    const cn = typeof props.className === 'string' ? props.className : '';
+    if (cn.includes('katex')) return true;
+    if (props.children) return containsKatex(props.children as React.ReactNode);
+    return false;
+  });
+}
+
 export const MarkdownRenderer = React.memo(function MarkdownRenderer({ content }: MarkdownRendererProps) {
   const { resolvedTheme } = useTheme();
+  // resolvedTheme is undefined during SSR but resolved on the client, so a
+  // theme-dependent code style mismatches between the two renders (hydration
+  // error #418). Stay on the light style until mounted, then switch.
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
   const codeStyle =
-    resolvedTheme === 'dark'
+    mounted && resolvedTheme === 'dark'
       ? oneDark
       : {
           ...oneLight,
@@ -21,15 +54,26 @@ export const MarkdownRenderer = React.memo(function MarkdownRenderer({ content }
           'code[class*="language-"]': { ...oneLight['code[class*="language-"]'], background: '#e5e7eb' },
         };
 
+  const remarkPlugins = React.useMemo<PluggableList>(() => [remarkGfm, remarkMath], []);
+  const rehypePlugins = React.useMemo<PluggableList>(() => [[rehypeKatex, REHYPE_KATEX_OPTIONS]], []);
+
   return (
     <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
+      remarkPlugins={remarkPlugins}
+      rehypePlugins={rehypePlugins}
       components={{
         p: ({ children }) => {
+          if (containsKatex(children)) {
+            return (
+              <KatexScrollContainer tag="p" className="mb-2">
+                {children}
+              </KatexScrollContainer>
+            );
+          }
           if (typeof children === 'string') {
             const parts = children.split('\n');
             return (
-              <p className="mb-2">
+              <p className="mb-2 overflow-x-auto">
                 {parts.map((part, i) => (
                   <React.Fragment key={i}>
                     {i > 0 && <br />}
@@ -39,7 +83,7 @@ export const MarkdownRenderer = React.memo(function MarkdownRenderer({ content }
               </p>
             );
           }
-          return <p className="mb-2">{children}</p>;
+          return <p className="mb-2 overflow-x-auto">{children}</p>;
         },
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         code(props: any) {
@@ -70,7 +114,14 @@ export const MarkdownRenderer = React.memo(function MarkdownRenderer({ content }
 
         ul: ({ children }) => <ul className="list-disc list-inside mb-2 space-y-1">{children}</ul>,
         ol: ({ children }) => <ol className="list-decimal list-inside mb-2 space-y-1">{children}</ol>,
-        li: ({ children }) => <li className="ml-2">{children}</li>,
+        li: ({ children }) =>
+          containsKatex(children) ? (
+            <KatexScrollContainer tag="li" className="ml-2">
+              {children}
+            </KatexScrollContainer>
+          ) : (
+            <li className="ml-2 overflow-x-auto">{children}</li>
+          ),
         blockquote: ({ children }) => (
           <blockquote className="border-l-4 border-gray-300 dark:border-gray-600 pl-4 italic mb-2">
             {children}

--- a/packages/webapp/src/hooks/use-scroll-overflow.ts
+++ b/packages/webapp/src/hooks/use-scroll-overflow.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useRef, useCallback } from 'react';
+
+export function useScrollOverflow<T extends HTMLElement>() {
+  const ref = useRef<T>(null);
+
+  const update = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    const overflowing = el.scrollWidth > el.clientWidth + 1;
+    el.dataset.overflowing = String(overflowing);
+    if (!overflowing) {
+      delete el.dataset.atStart;
+      delete el.dataset.atEnd;
+      return;
+    }
+    el.dataset.atStart = String(el.scrollLeft <= 1);
+    el.dataset.atEnd = String(el.scrollLeft + el.clientWidth >= el.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    update();
+    el.addEventListener('scroll', update, { passive: true });
+
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+
+    return () => {
+      el.removeEventListener('scroll', update);
+      ro.disconnect();
+    };
+  }, [update]);
+
+  return ref;
+}

--- a/packages/webapp/src/lib/escape-price-dollars.test.ts
+++ b/packages/webapp/src/lib/escape-price-dollars.test.ts
@@ -26,13 +26,14 @@ describe('escapePriceDollars', () => {
   // -- Real-world examples that demonstrate the price-dollar pairing bug --
 
   const EXAMPLE_1 =
-    '直すには A の絵を作り直しで **+$0.21〜0.25** かかるんだけど、承認もらってる \\$7 枠がほぼ使い切り（≈$6.86）なので、超過分のOKが要る状態にゃ。';
+    'Redrawing artwork A costs **+$0.21~0.25** extra, but the approved \\$7 budget is nearly spent (approx $6.86), so overage approval is needed.';
 
-  const EXAMPLE_2 = '新トランシェ **$1.00** を承認する（旧$0.60枠とは別勘定・CALLS.jsonl は継続追記）。';
+  const EXAMPLE_2 = 'Approve new tranche **$1.00** (separate from old $0.60 budget; CALLS.jsonl continues appending).';
 
-  const EXAMPLE_3 = '消費 $0.52 / 残 $0.08。次手は裁定不要と自己判断: **$0 の決定論クローンで plate 作成を先行**';
+  const EXAMPLE_3 =
+    'Spent $0.52 / remaining $0.08. Next step self-assessed as no arbitration needed: **$0 deterministic clone to create plate first**';
 
-  const EXAMPLE_4 = '消費 **$0.59 / 予算 $0.60 / 残 $0.01**・追加生成不可。';
+  const EXAMPLE_4 = 'Spent **$0.59 / budget $0.60 / remaining $0.01** — no further generation allowed.';
 
   describe('without preprocessor — demonstrates the bug', () => {
     test('example 1: unescaped $0.21 and $6.86 form spurious math pair', () => {
@@ -364,21 +365,24 @@ describe('escapePriceDollars', () => {
   });
 
   describe('R-1: price patterns with - and / are escaped', () => {
-    test('$0.60/回 with \\$1.20 mixed — slash price is escaped, already-escaped preserved', () => {
+    // CJK adjacency: tests slash-price next to CJK characters
+    test('slash price adjacent to CJK chars is escaped, already-escaped preserved', () => {
       const input = '1回あたり$0.60/回で、合計\\$1.20になるにゃ';
       const processed = escapePriceDollars(input);
       expect(processed).toContain('\\$0.60');
       expect(processed).not.toContain('\\\\$1.20');
     });
 
-    test('$100-200（残り$50-60）— dash ranges are escaped', () => {
+    // CJK adjacency: tests dash-range prices surrounded by CJK text
+    test('dash-range prices surrounded by CJK text are escaped', () => {
       const input = '予算$100-200（残り$50-60）で対応';
       const processed = escapePriceDollars(input);
       expect(processed).toContain('\\$100');
       expect(processed).toContain('\\$50');
     });
 
-    test('$0.60/回 does not pair with later \\$ to form math', () => {
+    // CJK adjacency: slash-price in CJK context must not pair with later \$ as math
+    test('slash price in CJK context does not pair with later escaped dollar as math', () => {
       const input = '消費$0.60/回で計算。予算は\\$7枠にゃ。';
       const processed = escapePriceDollars(input);
       const html = renderMarkdown(processed);
@@ -442,7 +446,8 @@ describe('escapePriceDollars', () => {
       expect(processed).not.toContain('\\\\$5M');
     });
 
-    test('月$100+かかる（残り$80）— + followed by CJK is price', () => {
+    // CJK adjacency: + followed by CJK character means price, not math
+    test('plus sign followed by CJK character is treated as price', () => {
       const input = '月$100+かかる（残り$80）';
       const processed = escapePriceDollars(input);
       expect(processed).toContain('\\$100');

--- a/packages/webapp/src/lib/escape-price-dollars.test.ts
+++ b/packages/webapp/src/lib/escape-price-dollars.test.ts
@@ -28,14 +28,11 @@ describe('escapePriceDollars', () => {
   const EXAMPLE_1 =
     '直すには A の絵を作り直しで **+$0.21〜0.25** かかるんだけど、承認もらってる \\$7 枠がほぼ使い切り（≈$6.86）なので、超過分のOKが要る状態にゃ。';
 
-  const EXAMPLE_2 =
-    '新トランシェ **$1.00** を承認する（旧$0.60枠とは別勘定・CALLS.jsonl は継続追記）。';
+  const EXAMPLE_2 = '新トランシェ **$1.00** を承認する（旧$0.60枠とは別勘定・CALLS.jsonl は継続追記）。';
 
-  const EXAMPLE_3 =
-    '消費 $0.52 / 残 $0.08。次手は裁定不要と自己判断: **$0 の決定論クローンで plate 作成を先行**';
+  const EXAMPLE_3 = '消費 $0.52 / 残 $0.08。次手は裁定不要と自己判断: **$0 の決定論クローンで plate 作成を先行**';
 
-  const EXAMPLE_4 =
-    '消費 **$0.59 / 予算 $0.60 / 残 $0.01**・追加生成不可。';
+  const EXAMPLE_4 = '消費 **$0.59 / 予算 $0.60 / 残 $0.01**・追加生成不可。';
 
   describe('without preprocessor — demonstrates the bug', () => {
     test('example 1: unescaped $0.21 and $6.86 form spurious math pair', () => {
@@ -231,7 +228,7 @@ describe('escapePriceDollars', () => {
     });
 
     test("fenced code block with $' is untouched", () => {
-      const input = "```js\nstr.replace(/a/, \"$'\");\n```";
+      const input = '```js\nstr.replace(/a/, "$\'");\n```';
       const processed = escapePriceDollars(input);
       expect(processed).toBe(input);
     });

--- a/packages/webapp/src/lib/escape-price-dollars.test.ts
+++ b/packages/webapp/src/lib/escape-price-dollars.test.ts
@@ -1,0 +1,509 @@
+import { describe, expect, test } from 'vitest';
+import rehypeKatex from 'rehype-katex';
+import rehypeStringify from 'rehype-stringify';
+import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+import { unified } from 'unified';
+import { escapePriceDollars } from './escape-price-dollars';
+
+const REHYPE_KATEX_OPTIONS = { errorColor: 'currentColor' } as const;
+
+function renderMarkdown(markdown: string): string {
+  return unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkMath)
+    .use(remarkRehype)
+    .use(rehypeKatex, REHYPE_KATEX_OPTIONS)
+    .use(rehypeStringify)
+    .processSync(markdown)
+    .toString();
+}
+
+describe('escapePriceDollars', () => {
+  // -- Real-world examples that demonstrate the price-dollar pairing bug --
+
+  const EXAMPLE_1 =
+    '直すには A の絵を作り直しで **+$0.21〜0.25** かかるんだけど、承認もらってる \\$7 枠がほぼ使い切り（≈$6.86）なので、超過分のOKが要る状態にゃ。';
+
+  const EXAMPLE_2 =
+    '新トランシェ **$1.00** を承認する（旧$0.60枠とは別勘定・CALLS.jsonl は継続追記）。';
+
+  const EXAMPLE_3 =
+    '消費 $0.52 / 残 $0.08。次手は裁定不要と自己判断: **$0 の決定論クローンで plate 作成を先行**';
+
+  const EXAMPLE_4 =
+    '消費 **$0.59 / 予算 $0.60 / 残 $0.01**・追加生成不可。';
+
+  describe('without preprocessor — demonstrates the bug', () => {
+    test('example 1: unescaped $0.21 and $6.86 form spurious math pair', () => {
+      const html = renderMarkdown(EXAMPLE_1);
+      expect(html).toMatch(/katex/);
+    });
+
+    test('example 2: $1.00 and $0.60 form spurious math pair', () => {
+      const html = renderMarkdown(EXAMPLE_2);
+      expect(html).toMatch(/katex/);
+    });
+
+    test('example 3: $0.52 and $0.08 form spurious math pair', () => {
+      const html = renderMarkdown(EXAMPLE_3);
+      expect(html).toMatch(/katex/);
+    });
+
+    test('example 4: multiple price dollars form spurious math', () => {
+      const html = renderMarkdown(EXAMPLE_4);
+      expect(html).toMatch(/katex/);
+    });
+  });
+
+  describe('with preprocessor — prices are literal, math is preserved', () => {
+    test('example 1: prices render as literal text, no spurious math', () => {
+      const processed = escapePriceDollars(EXAMPLE_1);
+      const html = renderMarkdown(processed);
+      expect(html).not.toMatch(/class="katex"/);
+      expect(html).toContain('$0.21');
+      expect(html).toContain('$7');
+      expect(html).toContain('$6.86');
+    });
+
+    test('example 2: prices render as literal text', () => {
+      const processed = escapePriceDollars(EXAMPLE_2);
+      const html = renderMarkdown(processed);
+      expect(html).not.toMatch(/class="katex"/);
+      expect(html).toContain('$1.00');
+      expect(html).toContain('$0.60');
+    });
+
+    test('example 3: prices render as literal text', () => {
+      const processed = escapePriceDollars(EXAMPLE_3);
+      const html = renderMarkdown(processed);
+      expect(html).not.toMatch(/class="katex"/);
+      expect(html).toContain('$0.52');
+      expect(html).toContain('$0.08');
+      expect(html).toContain('$0');
+    });
+
+    test('example 4: prices render as literal text', () => {
+      const processed = escapePriceDollars(EXAMPLE_4);
+      const html = renderMarkdown(processed);
+      expect(html).not.toMatch(/class="katex"/);
+      expect(html).toContain('$0.59');
+      expect(html).toContain('$0.60');
+      expect(html).toContain('$0.01');
+    });
+  });
+
+  describe('real math is preserved (C-2 fixes)', () => {
+    test('inline math $E=mc^2$ still renders as KaTeX', () => {
+      const processed = escapePriceDollars('Inline: $E=mc^2$ here');
+      const html = renderMarkdown(processed);
+      expect(html).toMatch(/class="katex"/);
+      expect(html).toContain('E=mc^2');
+    });
+
+    test('block math $$...$$ still renders', () => {
+      const input = '$$\n\\sum_{i=1}^n i\n$$';
+      const processed = escapePriceDollars(input);
+      const html = renderMarkdown(processed);
+      expect(html).toMatch(/class="katex-display"/);
+    });
+
+    test('math starting with digit followed by backslash: $2\\pi r$ is preserved', () => {
+      const processed = escapePriceDollars('Circle: $2\\pi r$ is circumference');
+      const html = renderMarkdown(processed);
+      expect(html).toMatch(/class="katex"/);
+    });
+
+    test('math starting with digit followed by plus: $2+2=4$ is preserved', () => {
+      const processed = escapePriceDollars('Simple: $2+2=4$ math');
+      const html = renderMarkdown(processed);
+      expect(html).toMatch(/class="katex"/);
+    });
+
+    test('display math with digits inside: $$12+3$$ is preserved', () => {
+      const processed = escapePriceDollars('Result: $$12+3$$');
+      const html = renderMarkdown(processed);
+      expect(html).toMatch(/class="katex"/);
+    });
+
+    test('math like $n$ is preserved', () => {
+      const processed = escapePriceDollars('For $n$ items');
+      const html = renderMarkdown(processed);
+      expect(html).toMatch(/class="katex"/);
+    });
+
+    test('math $3x + 2$ is preserved (digit followed by letter = math variable)', () => {
+      const processed = escapePriceDollars('Calculate $3x + 2$ now');
+      // $3 followed by 'x' (alphabetic) = math variable, not escaped
+      expect(processed).not.toContain('\\$3');
+      const html = renderMarkdown(processed);
+      expect(html).toMatch(/class="katex"/);
+    });
+
+    // Known limitation: $3 x + 2$ (digit, space, then math) is indistinguishable
+    // from a price. Agents should start math with a letter or `\`.
+    test('known limitation: $3 x + 2$ is treated as price (agents should use \\3 or 3x)', () => {
+      const processed = escapePriceDollars('Value $3 x + 2$ end');
+      // $3 matches price pattern (digit followed by space, not math-continuation)
+      expect(processed).toContain('\\$3');
+    });
+  });
+
+  describe('C-3: expanded numeric patterns', () => {
+    test('$100k is escaped as price', () => {
+      const processed = escapePriceDollars('Costs $100k to build');
+      expect(processed).toContain('\\$100k');
+    });
+
+    test('$1,000 is escaped as price', () => {
+      const processed = escapePriceDollars('Price is $1,000 total');
+      expect(processed).toContain('\\$1,000');
+    });
+
+    test('$2.5M is escaped as price', () => {
+      const processed = escapePriceDollars('Revenue $2.5M this quarter');
+      expect(processed).toContain('\\$2.5M');
+    });
+
+    test('$100k~$200k range is escaped', () => {
+      const processed = escapePriceDollars('Budget $100k~$200k range');
+      expect(processed).toContain('\\$100k');
+      expect(processed).toContain('\\$200k');
+    });
+
+    test('$1,234.56 is escaped as price', () => {
+      const processed = escapePriceDollars('Total $1,234.56 billed');
+      expect(processed).toContain('\\$1,234.56');
+    });
+
+    test('$500B is escaped as price', () => {
+      const processed = escapePriceDollars('Market cap $500B');
+      expect(processed).toContain('\\$500B');
+    });
+  });
+
+  describe('C-1: code blocks with special replacement patterns', () => {
+    test('inline code containing $$ is preserved exactly', () => {
+      const input = 'Use `$$` for display math';
+      const processed = escapePriceDollars(input);
+      expect(processed).toBe(input);
+      const html = renderMarkdown(processed);
+      expect(html).toContain('<code>$$</code>');
+    });
+
+    test('inline code containing $& is preserved exactly', () => {
+      const input = 'The pattern `$&` matches the whole match';
+      const processed = escapePriceDollars(input);
+      expect(processed).toBe(input);
+      const html = renderMarkdown(processed);
+      expect(html).toContain('<code>');
+      expect(html).toContain('$');
+    });
+
+    test("inline code containing $' is preserved exactly", () => {
+      const input = "Use `$'` for the string after match";
+      const processed = escapePriceDollars(input);
+      expect(processed).toBe(input);
+      const html = renderMarkdown(processed);
+      expect(html).toContain('<code>');
+      expect(html).toContain('$');
+    });
+
+    test('inline code containing $` is preserved exactly', () => {
+      const input = 'Use `$\\`` for the string before match';
+      const processed = escapePriceDollars(input);
+      expect(processed).toBe(input);
+    });
+
+    test('fenced code block with $$ is untouched', () => {
+      const input = '```js\nconst x = `$$`;\n```';
+      const processed = escapePriceDollars(input);
+      expect(processed).toBe(input);
+    });
+
+    test('fenced code block with $& is untouched', () => {
+      const input = '```js\nstr.replace(/a/, "$&b");\n```';
+      const processed = escapePriceDollars(input);
+      expect(processed).toBe(input);
+    });
+
+    test("fenced code block with $' is untouched", () => {
+      const input = "```js\nstr.replace(/a/, \"$'\");\n```";
+      const processed = escapePriceDollars(input);
+      expect(processed).toBe(input);
+    });
+
+    test('fenced code block with $100 is untouched', () => {
+      const input = '```bash\necho $100\nlet total = $200;\n```';
+      const processed = escapePriceDollars(input);
+      expect(processed).toBe(input);
+    });
+
+    test('inline code with $VAR is untouched', () => {
+      const input = 'The variable `$1` is special';
+      const processed = escapePriceDollars(input);
+      expect(processed).toBe(input);
+    });
+  });
+
+  describe('W-1: unclosed fenced code block (streaming)', () => {
+    test('unclosed fence protects everything after it', () => {
+      const input = 'Text before\n```python\nprint($100)\nx = $200\n';
+      const processed = escapePriceDollars(input);
+      // The unclosed fence should protect $100 and $200 from being escaped
+      expect(processed).toContain('$100');
+      expect(processed).toContain('$200');
+      expect(processed).not.toContain('\\$100');
+      expect(processed).not.toContain('\\$200');
+    });
+
+    test('unclosed fence with tilde', () => {
+      const input = 'Before\n~~~bash\necho $50\n';
+      const processed = escapePriceDollars(input);
+      expect(processed).toContain('$50');
+      expect(processed).not.toContain('\\$50');
+    });
+
+    test('text before unclosed fence is still processed', () => {
+      const input = 'Price is $100 total\n```python\necho $200\n';
+      const processed = escapePriceDollars(input);
+      expect(processed).toContain('\\$100');
+      expect(processed).not.toContain('\\$200');
+    });
+  });
+
+  describe('W-3: paragraph-spanning backtick prevention', () => {
+    test('backticks on different lines do not form code span', () => {
+      const input = 'Price `starts here\n\nand $100 ends` here';
+      const processed = escapePriceDollars(input);
+      // $100 should be escaped because backticks spanning paragraphs
+      // are NOT treated as inline code
+      expect(processed).toContain('\\$100');
+    });
+
+    test('backtick on one line does not pair with backtick on next line', () => {
+      const input = 'See `$50 on first line\nand $100` on second';
+      const processed = escapePriceDollars(input);
+      // Newline breaks inline code span matching, so both should be escaped
+      expect(processed).toContain('\\$50');
+      expect(processed).toContain('\\$100');
+    });
+  });
+
+  describe('already-escaped dollars are not double-escaped', () => {
+    test('\\$7 stays as \\$7', () => {
+      const input = 'Budget: \\$7 remaining';
+      const processed = escapePriceDollars(input);
+      expect(processed).toBe(input);
+    });
+
+    test('mixed escaped and unescaped', () => {
+      const input = 'Spent $0.21, budget \\$7';
+      const processed = escapePriceDollars(input);
+      expect(processed).toContain('\\$0.21');
+      expect(processed).toContain('\\$7');
+      expect(processed).not.toContain('\\\\$7');
+    });
+  });
+
+  describe('edge cases', () => {
+    test('$0 followed by space is escaped', () => {
+      const processed = escapePriceDollars('Cost is $0 here');
+      expect(processed).toContain('\\$0');
+    });
+
+    test('$0 at end of string is escaped', () => {
+      const processed = escapePriceDollars('Cost is $0');
+      expect(processed).toContain('\\$0');
+    });
+
+    test('dollar in URL is not affected (no digit after)', () => {
+      const input = 'See https://example.com/path';
+      const processed = escapePriceDollars(input);
+      expect(processed).toBe(input);
+    });
+
+    test('$$ display math delimiter is not touched', () => {
+      const input = '$$x + y = z$$';
+      const processed = escapePriceDollars(input);
+      expect(processed).toBe(input);
+    });
+
+    test('math with digit and equals: $2=1+1$ is preserved', () => {
+      const processed = escapePriceDollars('Check: $2=1+1$');
+      // 2 followed by = is math continuation
+      expect(processed).not.toContain('\\$2');
+    });
+
+    test('math with digit and caret: $2^{10}$ is preserved', () => {
+      const processed = escapePriceDollars('Value: $2^{10}$');
+      expect(processed).not.toContain('\\$2');
+    });
+
+    test('math with digit and underscore: $2_{max}$ is preserved', () => {
+      const processed = escapePriceDollars('Index: $2_{max}$');
+      expect(processed).not.toContain('\\$2');
+    });
+
+    // $2-1$ is now treated as price (- is not math continuation; use \frac{} or (2-1) instead)
+    test('known limitation: $2-1$ is treated as price (agents should use letter-start)', () => {
+      const processed = escapePriceDollars('Calc: $2-1$');
+      expect(processed).toContain('\\$2');
+    });
+
+    test('math with digit and star: $2*3$ is preserved', () => {
+      const processed = escapePriceDollars('Mul: $2*3$');
+      expect(processed).not.toContain('\\$2');
+    });
+
+    // $2/3$ is now treated as price (/ is not math continuation; use \frac{2}{3} instead)
+    test('known limitation: $2/3$ is treated as price (agents should use \\frac)', () => {
+      const processed = escapePriceDollars('Div: $2/3$');
+      expect(processed).toContain('\\$2');
+    });
+  });
+
+  describe('R-1: price patterns with - and / are escaped', () => {
+    test('$0.60/回 with \\$1.20 mixed — slash price is escaped, already-escaped preserved', () => {
+      const input = '1回あたり$0.60/回で、合計\\$1.20になるにゃ';
+      const processed = escapePriceDollars(input);
+      expect(processed).toContain('\\$0.60');
+      expect(processed).not.toContain('\\\\$1.20');
+    });
+
+    test('$100-200（残り$50-60）— dash ranges are escaped', () => {
+      const input = '予算$100-200（残り$50-60）で対応';
+      const processed = escapePriceDollars(input);
+      expect(processed).toContain('\\$100');
+      expect(processed).toContain('\\$50');
+    });
+
+    test('$0.60/回 does not pair with later \\$ to form math', () => {
+      const input = '消費$0.60/回で計算。予算は\\$7枠にゃ。';
+      const processed = escapePriceDollars(input);
+      const html = renderMarkdown(processed);
+      expect(html).not.toMatch(/class="katex"/);
+    });
+
+    test('$100-$200 range is fully escaped', () => {
+      const input = 'Budget $100-$200 range';
+      const processed = escapePriceDollars(input);
+      expect(processed).toContain('\\$100');
+      expect(processed).toContain('\\$200');
+    });
+  });
+
+  describe('L-1: indented fenced code blocks (0-3 spaces, CommonMark spec)', () => {
+    test('list-nested ```bash with awk $1 is protected', () => {
+      const input = '- Run this:\n   ```bash\n   awk $1 file.txt\n   echo $200\n   ```\nCost $50 total';
+      const processed = escapePriceDollars(input);
+      // Inside indented fence: protected
+      expect(processed).not.toContain('\\$1');
+      expect(processed).not.toContain('\\$200');
+      // Outside fence: escaped
+      expect(processed).toContain('\\$50');
+    });
+
+    test('2-space indented fence is detected', () => {
+      const input = '  ```python\n  x = $100\n  ```\nPrice $30';
+      const processed = escapePriceDollars(input);
+      expect(processed).not.toContain('\\$100');
+      expect(processed).toContain('\\$30');
+    });
+
+    test('3-space indented fence is detected (max allowed)', () => {
+      const input = '   ```js\n   let cost = $250;\n   ```\nBudget $80';
+      const processed = escapePriceDollars(input);
+      expect(processed).not.toContain('\\$250');
+      expect(processed).toContain('\\$80');
+    });
+
+    test('4-space indent is NOT treated as fence (known limitation)', () => {
+      const input = '    ```bash\n    echo $100\n    ```\nPrice $50';
+      const processed = escapePriceDollars(input);
+      // 4 spaces = not a fence, so $100 gets escaped (known limitation)
+      expect(processed).toContain('\\$100');
+      expect(processed).toContain('\\$50');
+    });
+
+    test('indented closing fence also detected', () => {
+      const input = '```bash\necho $100\n   ```\nPrice $50';
+      const processed = escapePriceDollars(input);
+      expect(processed).not.toContain('\\$100');
+      expect(processed).toContain('\\$50');
+    });
+  });
+
+  describe('W-b: plus sign lookahead for price vs math', () => {
+    test('$2M+ round is treated as price (+ followed by space)', () => {
+      const input = 'Series A raised $2M+ and targeting \\$5M next';
+      const processed = escapePriceDollars(input);
+      expect(processed).toContain('\\$2M');
+      expect(processed).not.toContain('\\\\$5M');
+    });
+
+    test('月$100+かかる（残り$80）— + followed by CJK is price', () => {
+      const input = '月$100+かかる（残り$80）';
+      const processed = escapePriceDollars(input);
+      expect(processed).toContain('\\$100');
+      expect(processed).toContain('\\$80');
+      const html = renderMarkdown(processed);
+      expect(html).not.toMatch(/class="katex"/);
+    });
+
+    test('$100+ at end of string is price', () => {
+      const processed = escapePriceDollars('Budget is $100+');
+      expect(processed).toContain('\\$100');
+    });
+
+    test('$2+2=4$ is still math (+ followed by digit)', () => {
+      const processed = escapePriceDollars('Simple: $2+2=4$ math');
+      expect(processed).not.toContain('\\$2');
+      const html = renderMarkdown(processed);
+      expect(html).toMatch(/class="katex"/);
+    });
+
+    test('$2+x$ is still math (+ followed by letter)', () => {
+      const processed = escapePriceDollars('Expr: $2+x$ end');
+      expect(processed).not.toContain('\\$2');
+    });
+  });
+
+  describe('F-1: longer closing fence is recognized', () => {
+    test('```` closing ``` block — longer fence correctly closes', () => {
+      const input = '```js\nconst x = $100;\n````\nPrice is $50 here';
+      const processed = escapePriceDollars(input);
+      // $100 inside the fence is protected
+      expect(processed).not.toContain('\\$100');
+      // $50 outside the fence is escaped
+      expect(processed).toContain('\\$50');
+    });
+
+    test('```` opening with ````` closing', () => {
+      const input = '````python\ny = $200\n`````\nCost $30 total';
+      const processed = escapePriceDollars(input);
+      expect(processed).not.toContain('\\$200');
+      expect(processed).toContain('\\$30');
+    });
+
+    test('~~~~ closing ~~~ block', () => {
+      const input = '~~~bash\necho $99\n~~~~\nBill $10';
+      const processed = escapePriceDollars(input);
+      expect(processed).not.toContain('\\$99');
+      expect(processed).toContain('\\$10');
+    });
+
+    test('shorter fence does NOT close the block', () => {
+      const input = '````js\nconst x = $100;\n```\nstill inside $200\n````\nPrice $50';
+      const processed = escapePriceDollars(input);
+      // Both $100 and $200 are inside the fence (``` doesn't close ```` )
+      expect(processed).not.toContain('\\$100');
+      expect(processed).not.toContain('\\$200');
+      // $50 is outside
+      expect(processed).toContain('\\$50');
+    });
+  });
+});

--- a/packages/webapp/src/lib/escape-price-dollars.ts
+++ b/packages/webapp/src/lib/escape-price-dollars.ts
@@ -1,0 +1,133 @@
+/**
+ * Pre-processor that escapes dollar signs used as currency/price markers so
+ * that `remark-math` (with `singleDollarTextMath: true`) does not
+ * accidentally pair them into spurious inline-math spans.
+ *
+ * A "price dollar" is defined as `$` immediately followed by a numeric token
+ * (digits with optional commas, optional decimal, optional suffix k/K/M/B).
+ * Examples: `$0.21`, `$100`, `$1,000`, `$100k`, `$2.5M`.
+ *
+ * The character AFTER the numeric token must NOT indicate a math expression
+ * continuation. Math-continuation signals:
+ * - `\`, `=`, `^`, `_` directly after the number
+ * - `+` followed by a digit or letter (math operator, e.g. `$2+2=4$`)
+ * - `*` followed by a digit or letter (multiplication, not markdown bold)
+ * - An alphabetic character (variable like `$3x`)
+ *
+ * NOT treated as math continuation (high-frequency price patterns):
+ * - `-` (price ranges: $100-200)
+ * - `/` (per-unit prices: $0.60/回)
+ * - `+` followed by space/CJK/EOL (price suffix: $100+)
+ *
+ * Known limitations:
+ * - `$2-1$`, `$1/2$`, `$3 x + 2$` (digit-start math with `-`, `/`, or space)
+ *   are treated as prices. The base prompt instructs agents to start math
+ *   expressions with a letter or `\` to avoid this.
+ * - 4-space indented code blocks (no fence) are NOT protected. Only fenced
+ *   code blocks (``` or ~~~) are detected. This is acceptable because agent
+ *   output overwhelmingly uses fenced blocks.
+ *
+ * Exclusions:
+ * - Already-escaped `\$` sequences are left untouched.
+ * - `$$` (display math delimiter context) is excluded via lookbehind.
+ * - Content inside fenced code blocks (``` ... ```) is never modified.
+ *   Fences may be indented up to 3 spaces (CommonMark spec).
+ * - Content inside inline code spans (` ... `) is never modified.
+ * - Unclosed fenced code blocks (streaming) protect from fence-start to EOF.
+ */
+
+const INLINE_CODE = /`[^`\n]+`/g;
+
+const PRICE_DOLLAR = /(?<![\\$])\$(\d[\d,]*(?:\.\d+)?[kKMB]?)/g;
+
+function isMathContinuation(text: string, afterIdx: number): boolean {
+  const ch = text[afterIdx];
+  if (!ch) return false;
+
+  // Direct math operators (unambiguous with price patterns)
+  if (/^[\\=^_]/.test(ch)) return true;
+
+  // Alphabetic character immediately after number = likely a math variable ($3x, $2n)
+  if (/^[a-zA-Z]/.test(ch)) return true;
+
+  // `+` is ambiguous: could be price suffix ($100+) or math addition ($2+2)
+  // Treat as math only if followed by a digit or letter (e.g. $2+2, $2+x)
+  if (ch === '+') {
+    const next = text[afterIdx + 1];
+    if (next && /^[0-9a-zA-Z]/.test(next)) return true;
+    return false;
+  }
+
+  // `*` is ambiguous: could be markdown bold or math multiplication
+  // Treat as math only if followed by a digit or letter (e.g. $2*3, $2*x)
+  if (ch === '*') {
+    const next = text[afterIdx + 1];
+    if (next && /^[0-9a-zA-Z]/.test(next)) return true;
+  }
+
+  return false;
+}
+
+export function escapePriceDollars(markdown: string): string {
+  const preserved: { placeholder: string; original: string }[] = [];
+  let counter = 0;
+
+  function preserve(original: string): string {
+    const placeholder = `\x00PRESERVE${counter++}\x00`;
+    preserved.push({ placeholder, original });
+    return placeholder;
+  }
+
+  // Phase 1: Protect fenced code blocks via line-by-line scan.
+  // Opening fence: 0-3 spaces indent + 3+ backticks or tildes (CommonMark spec).
+  // Closing fence: same char type, length >= opening fence, 0-3 spaces indent.
+  const lines = markdown.split('\n');
+  const segments: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const openMatch = /^ {0,3}(`{3,}|~{3,})/.exec(lines[i]);
+    if (openMatch) {
+      const fenceChar = openMatch[1][0];
+      const fenceLen = openMatch[1].length;
+      const closeRe = new RegExp(`^ {0,3}\\${fenceChar}{${fenceLen},}\\s*$`);
+      const blockLines = [lines[i]];
+      i++;
+      let closed = false;
+      while (i < lines.length) {
+        blockLines.push(lines[i]);
+        if (closeRe.test(lines[i])) {
+          closed = true;
+          i++;
+          break;
+        }
+        i++;
+      }
+      // Whether closed or unclosed (streaming), protect the entire block
+      segments.push(preserve(blockLines.join('\n')));
+    } else {
+      segments.push(lines[i]);
+      i++;
+    }
+  }
+  let result = segments.join('\n');
+
+  // Phase 2: Protect inline code spans (single-line only to prevent paragraph-spanning)
+  result = result.replace(INLINE_CODE, (m) => preserve(m));
+
+  // Phase 3: Escape price dollars, but skip if followed by math-continuation signal
+  result = result.replace(PRICE_DOLLAR, (match, digits: string, offset: number) => {
+    const afterIdx = offset + match.length;
+    if (isMathContinuation(result, afterIdx)) {
+      return match;
+    }
+    return `\\$${digits}`;
+  });
+
+  // Phase 4: Restore preserved blocks using function replacement to avoid
+  // special replacement patterns ($$ $& $' $` etc.) in the original content
+  for (const { placeholder, original } of preserved) {
+    result = result.replace(placeholder, () => original);
+  }
+
+  return result;
+}

--- a/packages/webapp/src/lib/escape-price-dollars.ts
+++ b/packages/webapp/src/lib/escape-price-dollars.ts
@@ -16,7 +16,7 @@
  *
  * NOT treated as math continuation (high-frequency price patterns):
  * - `-` (price ranges: $100-200)
- * - `/` (per-unit prices: $0.60/回)
+ * - `/` (per-unit prices: $0.60/unit)
  * - `+` followed by space/CJK/EOL (price suffix: $100+)
  *
  * Known limitations:


### PR DESCRIPTION
## Summary

Add LaTeX/KaTeX math rendering to the markdown chat view, supporting both
inline (`$...$`) and display (`$$...$$`) math expressions.

## Changes

- **KaTeX integration**: Add `remark-math` + `rehype-katex` plugins to
  `MarkdownRenderer` for parsing and rendering math expressions
- **Scroll container**: Custom `KatexScrollContainer` component with
  `useScrollOverflow` hook provides horizontal scrolling for wide
  expressions, with CSS mask-image fade affordance at overflow edges
- **Price-dollar escaping**: Pre-processor (`escapePriceDollars`) prevents
  dollar signs used for prices (e.g. `$100`, `$0.21`) from being
  misinterpreted as math delimiters, while preserving intentional math
- **Hydration safety**: Theme-dependent code highlighting defers to
  client-side mount to avoid SSR/client mismatch
- **CSS**: Custom slim scrollbar, vertical overflow suppression, and
  `white-space: nowrap` for display-math containers

## Motivation

Chat messages from AI agents frequently contain mathematical notation
(cost calculations, formulas, algorithm complexity). Without native
rendering, users see raw LaTeX source which is hard to read.

## Testing

- Unit tests for `escapePriceDollars` (66 cases): price patterns, real
  math expressions, fenced/inline code protection, streaming scenarios
- TypeScript type-check passes for all modified packages
- Manual verification of inline/display math rendering and scroll behavior

## Self-contained

This PR is independent of other pending changes. All new files and
modifications are additive and do not conflict with the existing codebase.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
