### PR TITLE
feat(agent-core): improve CI tool to handle non-Actions checks

### DIFF
--- a/packages/agent-core/src/tools/ci/index.test.ts
+++ b/packages/agent-core/src/tools/ci/index.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { getPrCheckStatus } from './index';
+
+vi.mock('../command-execution', () => ({
+  executeCommand: vi.fn(),
+}));
+
+import { executeCommand } from '../command-execution';
+const mockExecuteCommand = vi.mocked(executeCommand);
+
+describe('getPrCheckStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('returns success when all checks pass', async () => {
+    mockExecuteCommand.mockResolvedValue({
+      stdout: JSON.stringify([
+        {
+          name: 'build',
+          state: 'SUCCESS',
+          workflow: 'CI',
+          link: 'https://github.com/owner/repo/actions/runs/12345/jobs/67890',
+          bucket: 'pass',
+        },
+        {
+          name: 'lint',
+          state: 'SUCCESS',
+          workflow: 'CI',
+          link: 'https://github.com/owner/repo/actions/runs/12345/jobs/67891',
+          bucket: 'pass',
+        },
+      ]),
+      stderr: '',
+    });
+
+    const result = await getPrCheckStatus('owner', 'repo', '1');
+    expect(result).toEqual({ status: 'success' });
+  });
+
+  test('returns in_progress when checks are pending', async () => {
+    mockExecuteCommand.mockResolvedValue({
+      stdout: JSON.stringify([
+        {
+          name: 'build',
+          state: 'PENDING',
+          workflow: 'CI',
+          link: 'https://github.com/owner/repo/actions/runs/12345/jobs/67890',
+          bucket: 'pending',
+        },
+        {
+          name: 'lint',
+          state: 'SUCCESS',
+          workflow: 'CI',
+          link: 'https://github.com/owner/repo/actions/runs/12345/jobs/67891',
+          bucket: 'pass',
+        },
+      ]),
+      stderr: '',
+    });
+
+    const result = await getPrCheckStatus('owner', 'repo', '1');
+    expect(result).toEqual({ status: 'in_progress' });
+  });
+
+  test('returns failure with Actions run IDs for failed GitHub Actions checks', async () => {
+    mockExecuteCommand.mockResolvedValue({
+      stdout: JSON.stringify([
+        {
+          name: 'build',
+          state: 'FAILURE',
+          workflow: 'CI',
+          link: 'https://github.com/owner/repo/actions/runs/99999/jobs/12345',
+          bucket: 'fail',
+        },
+        {
+          name: 'lint',
+          state: 'SUCCESS',
+          workflow: 'CI',
+          link: 'https://github.com/owner/repo/actions/runs/12345/jobs/67891',
+          bucket: 'pass',
+        },
+      ]),
+      stderr: '',
+    });
+
+    const result = await getPrCheckStatus('owner', 'repo', '1');
+    expect(result).toEqual({
+      status: 'failure',
+      failedActionsRuns: [{ runId: '99999', name: 'build' }],
+      failedExternalChecks: [],
+    });
+  });
+
+  test('handles non-Actions checks (CodeBuild) without crashing', async () => {
+    mockExecuteCommand.mockResolvedValue({
+      stdout: JSON.stringify([
+        {
+          name: 'CodeBuild - my-project',
+          state: 'FAILURE',
+          workflow: '',
+          link: 'https://ap-northeast-1.console.aws.amazon.com/codesuite/codebuild/projects/my-project/build/my-project:abc123',
+          bucket: 'fail',
+        },
+      ]),
+      stderr: '',
+    });
+
+    const result = await getPrCheckStatus('owner', 'repo', '148');
+    expect(result).toEqual({
+      status: 'failure',
+      failedActionsRuns: [],
+      failedExternalChecks: [
+        {
+          name: 'CodeBuild - my-project',
+          link: 'https://ap-northeast-1.console.aws.amazon.com/codesuite/codebuild/projects/my-project/build/my-project:abc123',
+          state: 'FAILURE',
+        },
+      ],
+    });
+  });
+
+  test('handles mix of failed Actions and non-Actions checks', async () => {
+    mockExecuteCommand.mockResolvedValue({
+      stdout: JSON.stringify([
+        {
+          name: 'CI Build',
+          state: 'FAILURE',
+          workflow: 'CI',
+          link: 'https://github.com/owner/repo/actions/runs/55555/jobs/11111',
+          bucket: 'fail',
+        },
+        {
+          name: 'CodeBuild - deploy',
+          state: 'FAILURE',
+          workflow: '',
+          link: 'https://ap-northeast-1.console.aws.amazon.com/codesuite/codebuild/projects/deploy/build/deploy:xyz789',
+          bucket: 'fail',
+        },
+        {
+          name: 'External CI',
+          state: 'FAILURE',
+          workflow: '',
+          link: 'https://ci.example.com/builds/42',
+          bucket: 'fail',
+        },
+        {
+          name: 'lint',
+          state: 'SUCCESS',
+          workflow: 'CI',
+          link: 'https://github.com/owner/repo/actions/runs/55555/jobs/11112',
+          bucket: 'pass',
+        },
+      ]),
+      stderr: '',
+    });
+
+    const result = await getPrCheckStatus('owner', 'repo', '1');
+    expect(result).toEqual({
+      status: 'failure',
+      failedActionsRuns: [{ runId: '55555', name: 'CI Build' }],
+      failedExternalChecks: [
+        {
+          name: 'CodeBuild - deploy',
+          link: 'https://ap-northeast-1.console.aws.amazon.com/codesuite/codebuild/projects/deploy/build/deploy:xyz789',
+          state: 'FAILURE',
+        },
+        {
+          name: 'External CI',
+          link: 'https://ci.example.com/builds/42',
+          state: 'FAILURE',
+        },
+      ],
+    });
+  });
+
+  test('handles all failed checks being non-Actions (no Actions runs)', async () => {
+    mockExecuteCommand.mockResolvedValue({
+      stdout: JSON.stringify([
+        {
+          name: 'CodeBuild A',
+          state: 'FAILURE',
+          workflow: '',
+          link: 'https://console.aws.amazon.com/codebuild/home',
+          bucket: 'fail',
+        },
+        {
+          name: 'Jenkins Build',
+          state: 'FAILURE',
+          workflow: '',
+          link: 'https://jenkins.example.com/job/build/123',
+          bucket: 'fail',
+        },
+      ]),
+      stderr: '',
+    });
+
+    const result = await getPrCheckStatus('owner', 'repo', '5');
+    expect(result).toEqual({
+      status: 'failure',
+      failedActionsRuns: [],
+      failedExternalChecks: [
+        {
+          name: 'CodeBuild A',
+          link: 'https://console.aws.amazon.com/codebuild/home',
+          state: 'FAILURE',
+        },
+        {
+          name: 'Jenkins Build',
+          link: 'https://jenkins.example.com/job/build/123',
+          state: 'FAILURE',
+        },
+      ],
+    });
+  });
+
+  test('throws error when no checks are found', async () => {
+    mockExecuteCommand.mockResolvedValue({
+      stdout: JSON.stringify([]),
+      stderr: '',
+    });
+
+    await expect(getPrCheckStatus('owner', 'repo', '1')).rejects.toThrow('No checks found for this PR');
+  });
+
+  test('handles checks with empty link gracefully', async () => {
+    mockExecuteCommand.mockResolvedValue({
+      stdout: JSON.stringify([
+        {
+          name: 'status-check',
+          state: 'FAILURE',
+          workflow: '',
+          link: '',
+          bucket: 'fail',
+        },
+      ]),
+      stderr: '',
+    });
+
+    const result = await getPrCheckStatus('owner', 'repo', '1');
+    expect(result).toEqual({
+      status: 'failure',
+      failedActionsRuns: [],
+      failedExternalChecks: [
+        {
+          name: 'status-check',
+          link: '',
+          state: 'FAILURE',
+        },
+      ],
+    });
+  });
+});

--- a/packages/agent-core/src/tools/ci/index.ts
+++ b/packages/agent-core/src/tools/ci/index.ts
@@ -11,10 +11,45 @@ const inputSchema = z.object({
     .describe('The sequential number of the pull request issued from GitHub, or the branch name.'),
 });
 
+interface ActionsRun {
+  runId: string;
+  name: string;
+}
+
+interface ExternalCheck {
+  name: string;
+  link: string;
+  state: string;
+}
+
+interface CheckStatusInProgress {
+  status: 'in_progress';
+}
+
+interface CheckStatusSuccess {
+  status: 'success';
+}
+
+interface CheckStatusFailure {
+  status: 'failure';
+  failedActionsRuns: ActionsRun[];
+  failedExternalChecks: ExternalCheck[];
+}
+
+type CheckStatusResult = CheckStatusInProgress | CheckStatusSuccess | CheckStatusFailure;
+
+const isActionsRunLink = (link: string | null | undefined): boolean => {
+  return !!link && link.includes('/actions/runs/');
+};
+
+const extractRunId = (link: string): string | undefined => {
+  const parts = link.split('/actions/runs/');
+  if (parts.length < 2) return undefined;
+  return parts[1].split('/')[0];
+};
+
 const getLatestRunResult = async (input: { owner: string; repo: string; pullRequestId: string }) => {
   const { owner, repo, pullRequestId } = input;
-  // If it is executed too soon, the workflow might not be queued yet, resulting in an empty success.
-  // To avoid it, we wait a bit here.
   await setTimeout(5000);
 
   while (true) {
@@ -27,14 +62,29 @@ const getLatestRunResult = async (input: { owner: string; repo: string; pullRequ
       if (checkResult.status === 'success') {
         return `CI succeeded without errors!`;
       } else if (checkResult.status === 'failure') {
-        const failed = checkResult.failedRuns;
-        const result: string = await execute(`gh run view ${failed[0].runId} -R ${owner}/${repo}`, true);
-        const logs: string = await execute(`gh run view ${failed[0].runId} -R ${owner}/${repo} --log-failed`, true);
-        logs
-          .split('\n')
-          .map((l) => l.split('\t').at(-1))
-          .join('\n');
-        return `CI failed with errors! <detail>${result}</detail>\n\nHere's the result of gh run view --log-failed:<log>${logs}</logs>`;
+        const parts: string[] = [];
+
+        if (checkResult.failedActionsRuns.length > 0) {
+          const firstRun = checkResult.failedActionsRuns[0];
+          const result: string = await execute(`gh run view ${firstRun.runId} -R ${owner}/${repo}`, true);
+          const logs: string = await execute(`gh run view ${firstRun.runId} -R ${owner}/${repo} --log-failed`, true);
+          const formattedLogs = logs
+            .split('\n')
+            .map((l) => l.split('\t').at(-1))
+            .join('\n');
+          parts.push(
+            `CI failed with errors! <detail>${result}</detail>\n\nHere's the result of gh run view --log-failed:<log>${formattedLogs}</log>`
+          );
+        }
+
+        if (checkResult.failedExternalChecks.length > 0) {
+          const externalSummary = checkResult.failedExternalChecks
+            .map((c) => `- ${c.name} (${c.state}): ${c.link}`)
+            .join('\n');
+          parts.push(`External checks failed:\n${externalSummary}`);
+        }
+
+        return parts.join('\n\n');
       }
     } catch (e) {
       console.log(e);
@@ -56,12 +106,11 @@ const execute = async (command: string, plain = false): Promise<any> => {
   return parsed;
 };
 
-const getPrCheckStatus = async (
+export const getPrCheckStatus = async (
   owner: string,
   repo: string,
   pullRequestId: string
-): Promise<{ status: 'in_progress' | 'success' } | { status: 'failure'; failedRuns: { runId: string }[] }> => {
-  // Use gh pr checks to get all check runs for the PR
+): Promise<CheckStatusResult> => {
   const checks = (await execute(
     `gh pr checks -R ${owner}/${repo} ${pullRequestId} --json state,name,workflow,link,bucket`
   )) as { link: string; name: string; state: string; workflow: string; bucket: string }[];
@@ -70,26 +119,37 @@ const getPrCheckStatus = async (
     throw new Error('No checks found for this PR');
   }
 
-  // bucket: pass, fail, pending, skipping, or cancel.
-  // Check if any workflow is still running
-  // We have to wait all the runs complete because otherwise we cannot get their execution log by gh run view command.
   const runningChecks = checks.filter((check) => ['pending'].includes(check.bucket));
 
   if (runningChecks.length > 0) {
     return { status: 'in_progress' };
   }
 
-  // Check if there is failed run
   const failedChecks = checks.filter((check) => check.bucket === 'fail');
-  const failedRuns = failedChecks.map((check) => {
-    const runId = check.link.split('/actions/runs/')[1].split('/')[0];
-    return { runId };
-  });
-  if (failedRuns.length > 0) {
-    return { status: 'failure', failedRuns };
+  if (failedChecks.length === 0) {
+    // cancel/skipping → treated as success
+    return { status: 'success' };
   }
 
-  return { status: 'success' };
+  const failedActionsRuns: ActionsRun[] = [];
+  const seenRunIds = new Set<string>();
+  const failedExternalChecks: ExternalCheck[] = [];
+
+  for (const check of failedChecks) {
+    if (isActionsRunLink(check.link)) {
+      const runId = extractRunId(check.link);
+      if (runId && !seenRunIds.has(runId)) {
+        seenRunIds.add(runId);
+        failedActionsRuns.push({ runId, name: check.name });
+      } else if (!runId) {
+        failedExternalChecks.push({ name: check.name, link: check.link, state: check.state });
+      }
+    } else {
+      failedExternalChecks.push({ name: check.name, link: check.link, state: check.state });
+    }
+  }
+
+  return { status: 'failure', failedActionsRuns, failedExternalChecks };
 };
 
 const name = 'getGitHubActionsLatestResult';

--- a/packages/agent-core/src/tools/command-execution/github.test.ts
+++ b/packages/agent-core/src/tools/command-execution/github.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { buildGhLoginEnv } from './github';
+
+describe('buildGhLoginEnv', () => {
+  it('removes GITHUB_TOKEN and GH_TOKEN from env', () => {
+    const env = {
+      HOME: '/root',
+      PATH: '/usr/bin',
+      GITHUB_TOKEN: 'ghs_secret123',
+      GH_TOKEN: 'ghs_another456',
+      OTHER_VAR: 'keep',
+    } as unknown as NodeJS.ProcessEnv;
+
+    const result = buildGhLoginEnv(env);
+
+    expect(result).not.toHaveProperty('GITHUB_TOKEN');
+    expect(result).not.toHaveProperty('GH_TOKEN');
+    expect(result).toHaveProperty('HOME', '/root');
+    expect(result).toHaveProperty('PATH', '/usr/bin');
+    expect(result).toHaveProperty('OTHER_VAR', 'keep');
+  });
+
+  it('works when neither token var is present', () => {
+    const env = {
+      HOME: '/root',
+      PATH: '/usr/bin',
+    } as unknown as NodeJS.ProcessEnv;
+
+    const result = buildGhLoginEnv(env);
+
+    expect(result).not.toHaveProperty('GITHUB_TOKEN');
+    expect(result).not.toHaveProperty('GH_TOKEN');
+    expect(result).toHaveProperty('HOME', '/root');
+    expect(result).toHaveProperty('PATH', '/usr/bin');
+  });
+});

--- a/packages/agent-core/src/tools/command-execution/github.ts
+++ b/packages/agent-core/src/tools/command-execution/github.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process';
+import { exec, spawn } from 'child_process';
 import { promisify } from 'util';
 const execAsync = promisify(exec);
 
@@ -14,6 +14,47 @@ export const isGitHubConfigured = () => {
   );
 };
 
+export const buildGhLoginEnv = (env: NodeJS.ProcessEnv): NodeJS.ProcessEnv => {
+  const { GITHUB_TOKEN, GH_TOKEN, ...rest } = env;
+  return rest;
+};
+
+const GH_LOGIN_TIMEOUT_MS = 10_000;
+
+const loginGhWithToken = (token: string, env: NodeJS.ProcessEnv): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const loginEnv = buildGhLoginEnv(env);
+    const proc = spawn('gh', ['auth', 'login', '--hostname', 'github.com', '--with-token'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: loginEnv,
+    });
+    let stderr = '';
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      proc.kill('SIGKILL');
+      reject(new Error(`gh auth login timed out after ${GH_LOGIN_TIMEOUT_MS}ms`));
+    }, GH_LOGIN_TIMEOUT_MS);
+    proc.stderr.on('data', (d) => (stderr += d.toString()));
+    proc.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(err);
+    });
+    proc.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (code === 0) resolve();
+      else reject(new Error(`gh auth login failed (code ${code}): ${stderr}`));
+    });
+    proc.stdin.write(token);
+    proc.stdin.end();
+  });
+};
+
 export const authorizeGitHubCli = async () => {
   if (cache.updatedAt > Date.now() - 50 * 60 * 1000) {
     return cache.token;
@@ -21,7 +62,6 @@ export const authorizeGitHubCli = async () => {
   if (process.env.GITHUB_PERSONAL_ACCESS_TOKEN) {
     cache.token = process.env.GITHUB_PERSONAL_ACCESS_TOKEN;
   } else if (
-    //
     process.env.GITHUB_APP_PRIVATE_KEY_PATH &&
     process.env.GITHUB_APP_ID &&
     process.env.GITHUB_APP_INSTALLATION_ID
@@ -39,12 +79,15 @@ export const authorizeGitHubCli = async () => {
     return undefined;
   }
 
-  await execAsync(`gh auth setup-git`, {
-    env: {
-      ...process.env,
-      GITHUB_TOKEN: cache.token,
-    },
-  });
+  const authEnv = {
+    ...process.env,
+    GITHUB_TOKEN: cache.token,
+  };
+
+  await execAsync(`gh auth setup-git`, { env: authEnv });
+
+  await loginGhWithToken(cache.token, authEnv);
+
   cache.updatedAt = Date.now();
   return cache.token;
 };


### PR DESCRIPTION
## Summary

Improve the CI status checking tool (`getGitHubActionsLatestResult`) to gracefully handle non-GitHub-Actions check suites (e.g., CodeBuild, third-party CI) and improve GitHub CLI authentication handling.

## Motivation

The existing CI tool assumes all PR checks are GitHub Actions runs. When a repository uses CodeBuild or other external CI providers, the tool crashes or returns misleading information. Additionally, the `gh` CLI authentication can conflict with environment-level tokens.

## Changes

- **CI status tool** (`packages/agent-core/src/tools/ci/index.ts`): Robust handling of mixed check types — identifies GitHub Actions runs for log retrieval while gracefully degrading for non-Actions checks
- **GitHub auth helper** (`packages/agent-core/src/tools/command-execution/github.ts`): New `buildGhLoginEnv` utility that strips `GITHUB_TOKEN`/`GH_TOKEN` from the process environment to prevent auth conflicts when using `gh auth login`
- 4 files changed, +428 / -32 lines

## Testing

- 10 unit tests across 2 test files:
  - `ci/index.test.ts`: 8 tests covering success, in-progress, failure with Actions runs, non-Actions checks, mixed scenarios, empty checks, and empty links
  - `github.test.ts`: 2 tests for token environment stripping
- `npm run build` (tsc) passes for agent-core

## Notes

This is a self-contained change affecting only agent-core's CI tooling. No changes to the tool's external interface.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
