### PR TITLE
fix(webapp): recover realtime events lost during WebSocket disconnects

### DIFF
--- a/packages/webapp/src/hooks/use-event-bus.ts
+++ b/packages/webapp/src/hooks/use-event-bus.ts
@@ -1,7 +1,14 @@
 import { decodeJWT } from 'aws-amplify/auth';
 import { Amplify } from 'aws-amplify';
-import { events } from 'aws-amplify/data';
+import { CONNECTION_STATE_CHANGE, events } from 'aws-amplify/data';
+import { Hub } from 'aws-amplify/utils';
 import { useEffect } from 'react';
+import {
+  CATCH_UP_POLL_INTERVAL_MS,
+  ConnectionHealthTracker,
+  reconnectDelayMs,
+  shouldReconnectOnVisible,
+} from '@/lib/realtime-connection';
 
 Amplify.configure(
   {
@@ -33,17 +40,59 @@ type UseEventBusProps = {
   onReceived: (payload: unknown) => void;
   onConnected?: () => void;
   onError?: (err: unknown) => void;
+  /**
+   * Called when realtime connectivity has (re-)established after a window in
+   * which events may have been lost, and periodically (while the page is
+   * visible) as long as the connection is known-unhealthy. AppSync Events has
+   * no replay: events published while the socket was down are gone, so use
+   * this to reconcile client state from server-side data (e.g.
+   * `router.refresh()` or re-running a fetch action). Must be referentially
+   * stable (wrap in `useCallback`), like the other callbacks.
+   */
+  onReconnected?: () => void;
 };
 
-export const useEventBus = ({ channelName, onReceived, onConnected, onError }: UseEventBusProps) => {
+export const useEventBus = ({ channelName, onReceived, onConnected, onError, onReconnected }: UseEventBusProps) => {
   useEffect(() => {
     let channel: Awaited<ReturnType<typeof events.connect>> | null = null;
     let isMounted = true;
+    // Increments on every (re)connect request and on unmount so that stale
+    // in-flight connects and their subscription callbacks can detect they
+    // have been superseded and dispose themselves.
+    let generation = 0;
+    let retryAttempt = 0;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    const health = new ConnectionHealthTracker();
+
+    const clearRetryTimer = () => {
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+      }
+    };
+
+    // Re-establish the subscription after a failure. The Amplify client
+    // re-subscribes existing subscriptions when *it* detects a disconnect,
+    // but a subscription that errored out (e.g. start-ack timeout on a
+    // half-open socket, auth failure at connect time) stays dead unless we
+    // retry it ourselves.
+    const scheduleReconnect = () => {
+      if (!isMounted || retryTimer) return;
+      retryTimer = setTimeout(() => {
+        retryTimer = null;
+        connectAndSubscribe();
+      }, reconnectDelayMs(retryAttempt++));
+    };
 
     const connectAndSubscribe = async () => {
+      const gen = ++generation;
+      if (channel) {
+        channel.close();
+        channel = null;
+      }
       try {
         const ch = await events.connect(`event-bus/${channelName}`);
-        if (!isMounted) {
+        if (!isMounted || gen !== generation) {
           ch.close();
           return;
         }
@@ -55,35 +104,116 @@ export const useEventBus = ({ channelName, onReceived, onConnected, onError }: U
           error: (err) => {
             console.error('EventBus error:', err);
             onError?.(err);
+            if (isMounted && gen === generation) {
+              // Subscription-level failures (e.g. EVENT_SUBSCRIBE_ERROR on an
+              // expired token) don't close the socket, so the connection
+              // state monitor never reports a lossy state. Track the loss
+              // window here so the catch-up fires once we resubscribe.
+              health.markDisrupted();
+              scheduleReconnect();
+            }
           },
         });
+        retryAttempt = 0;
+        if (health.recordSubscriptionEstablished()) {
+          onReconnected?.();
+        }
         onConnected?.();
       } catch (err) {
         console.error('EventBus connect error:', err);
         onError?.(err);
+        if (isMounted && gen === generation) {
+          health.markDisrupted();
+          scheduleReconnect();
+        }
       }
     };
 
     connectAndSubscribe();
 
-    const onVisibilityChange = () => {
-      if (document.visibilityState === 'visible' && isMounted) {
-        console.debug('Page became visible, reconnecting EventBus...');
-        if (channel) {
-          channel.close();
-          channel = null;
-        }
-        connectAndSubscribe();
+    // Monitor the health of the shared AppSync Events WebSocket. The Amplify
+    // client detects silent (half-open) disconnects via keep-alive monitoring
+    // and reconnects + re-subscribes on its own, but events published while
+    // the socket was down are lost forever (no replay). Whenever
+    // connectivity returns after a lossy window we notify the consumer so it
+    // can reconcile from server-side data.
+    const stopHubListener = Hub.listen('api', ({ payload }) => {
+      if (payload.event !== CONNECTION_STATE_CHANGE) return;
+      const state = (payload.data as { connectionState?: string } | undefined)?.connectionState;
+      if (!state) return;
+      const catchUpNeeded = health.recordState(state);
+      if (state === 'Connected') {
+        retryAttempt = 0;
       }
+      if (catchUpNeeded && isMounted) {
+        onReconnected?.();
+      }
+    });
+
+    // While the connection is known-unhealthy, keep the UI usable by
+    // periodically reconciling from the server (the client can take up to
+    // 5 minutes to hard-recover a half-open socket). Skipped for hidden
+    // tabs (visibilitychange covers those on return) and while the browser
+    // knows it is offline (the fetch would just fail; the 'online' handler
+    // below kicks in the moment connectivity returns).
+    const pollTimer = setInterval(() => {
+      if (!isMounted || !health.isDisrupted) return;
+      if (document.visibilityState !== 'visible') return;
+      if (!navigator.onLine) return;
+      onReconnected?.();
+    }, CATCH_UP_POLL_INTERVAL_MS);
+
+    const forceReconnect = () => {
+      if (!isMounted) return;
+      clearRetryTimer();
+      retryAttempt = 0;
+      // The unsubscribe→resubscribe gap of a forced reconnect is itself a
+      // window where published events are lost; make sure the catch-up runs
+      // after the new subscription is up.
+      health.markDisrupted();
+      connectAndSubscribe();
+    };
+
+    // Timestamp of the last transition to 'hidden'. Used to compute how long
+    // the page stayed in the background when it becomes visible again.
+    let hiddenAt: number | null = null;
+    const onVisibilityChange = () => {
+      if (!isMounted) return;
+      if (document.visibilityState === 'hidden') {
+        hiddenAt = Date.now();
+        return;
+      }
+      const hiddenDurationMs = hiddenAt === null ? 0 : Date.now() - hiddenAt;
+      hiddenAt = null;
+      // Skip quick alt-tabs while the connection is healthy: a forced
+      // reconnect always ends in the consumer's catch-up (full RSC refresh),
+      // which is expensive on mobile. Long background periods reconnect
+      // immediately (mobile browsers freeze sockets there), and a socket that
+      // silently died during a short hide is still recovered by the
+      // keep-alive monitor + CONNECTION_STATE_CHANGE path.
+      if (!shouldReconnectOnVisible(health.isDisrupted, hiddenDurationMs)) {
+        return;
+      }
+      console.log('Page became visible, reconnecting EventBus...');
+      forceReconnect();
     };
     document.addEventListener('visibilitychange', onVisibilityChange);
 
+    // When the browser regains network connectivity, don't wait for the
+    // keep-alive machinery to notice — reconnect right away.
+    window.addEventListener('online', forceReconnect);
+
     return () => {
       isMounted = false;
+      generation++;
+      clearRetryTimer();
+      clearInterval(pollTimer);
+      stopHubListener();
       document.removeEventListener('visibilitychange', onVisibilityChange);
+      window.removeEventListener('online', forceReconnect);
       if (channel) {
         channel.close();
       }
     };
-  }, [channelName, onReceived, onConnected, onError]);
+  }, [channelName, onReceived, onConnected, onError, onReconnected]);
 };

--- a/packages/webapp/src/lib/realtime-connection.test.ts
+++ b/packages/webapp/src/lib/realtime-connection.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ConnectionHealthTracker,
+  MIN_HIDDEN_DURATION_FOR_RECONNECT_MS,
+  reconnectDelayMs,
+  shouldReconnectOnVisible,
+} from './realtime-connection';
+
+describe('ConnectionHealthTracker', () => {
+  it('does not request catch-up on the initial connect sequence', () => {
+    const tracker = new ConnectionHealthTracker();
+    expect(tracker.recordState('Disconnected')).toBe(false);
+    expect(tracker.recordState('Connecting')).toBe(false);
+    expect(tracker.recordState('Connected')).toBe(false);
+    expect(tracker.isDisrupted).toBe(false);
+  });
+
+  it('requests catch-up when the connection recovers after a disruption', () => {
+    const tracker = new ConnectionHealthTracker();
+    tracker.recordState('Connected');
+    expect(tracker.recordState('ConnectionDisrupted')).toBe(false);
+    expect(tracker.isDisrupted).toBe(true);
+    expect(tracker.recordState('Connecting')).toBe(false);
+    expect(tracker.recordState('Connected')).toBe(true);
+    expect(tracker.isDisrupted).toBe(false);
+  });
+
+  it('requests catch-up after a silent disconnect detected via keep-alive', () => {
+    const tracker = new ConnectionHealthTracker();
+    tracker.recordState('Connected');
+    expect(tracker.recordState('ConnectedPendingKeepAlive')).toBe(false);
+    expect(tracker.isDisrupted).toBe(true);
+    // keep-alive resumes without a full reconnect
+    expect(tracker.recordState('Connected')).toBe(true);
+  });
+
+  it('requests catch-up when network drops and comes back', () => {
+    const tracker = new ConnectionHealthTracker();
+    tracker.recordState('Connected');
+    tracker.recordState('ConnectedPendingNetwork');
+    tracker.recordState('ConnectionDisruptedPendingNetwork');
+    tracker.recordState('Connecting');
+    expect(tracker.recordState('Connected')).toBe(true);
+  });
+
+  it('treats a clean disconnect after having been connected as lossy', () => {
+    const tracker = new ConnectionHealthTracker();
+    tracker.recordState('Connected');
+    tracker.recordState('ConnectedPendingDisconnect');
+    tracker.recordState('Disconnected');
+    expect(tracker.isDisrupted).toBe(true);
+    expect(tracker.recordState('Connected')).toBe(true);
+  });
+
+  it('requests catch-up when mounting while disrupted, once connected', () => {
+    // e.g. page loads while offline: SSR data goes stale until the socket
+    // finally connects, so a reconciliation is required then.
+    const tracker = new ConnectionHealthTracker();
+    tracker.recordState('Disconnected');
+    tracker.recordState('Connecting');
+    tracker.recordState('ConnectionDisrupted');
+    expect(tracker.recordState('Connected')).toBe(true);
+  });
+
+  it('only requests catch-up once per disruption', () => {
+    const tracker = new ConnectionHealthTracker();
+    tracker.recordState('Connected');
+    tracker.recordState('ConnectionDisrupted');
+    expect(tracker.recordState('Connected')).toBe(true);
+    expect(tracker.recordState('Connected')).toBe(false);
+  });
+
+  it('requests catch-up when a subscription error is recovered by resubscribing (C1)', () => {
+    // EVENT_SUBSCRIBE_ERROR / GQL_ERROR paths never emit a lossy Hub state
+    // (the socket stays open), so the hook marks the disruption itself and
+    // the catch-up fires when its own retry re-establishes the subscription.
+    const tracker = new ConnectionHealthTracker();
+    tracker.recordState('Connected');
+    tracker.markDisrupted();
+    expect(tracker.isDisrupted).toBe(true);
+    expect(tracker.recordSubscriptionEstablished()).toBe(true);
+    expect(tracker.isDisrupted).toBe(false);
+    // subsequent healthy resubscribes don't re-fire
+    expect(tracker.recordSubscriptionEstablished()).toBe(false);
+  });
+
+  it('does not request catch-up on the initial subscribe (no prior disruption)', () => {
+    const tracker = new ConnectionHealthTracker();
+    expect(tracker.recordSubscriptionEstablished()).toBe(false);
+  });
+
+  it('fires the catch-up exactly once when both recovery signals arrive (C1 + Hub)', () => {
+    const tracker = new ConnectionHealthTracker();
+    tracker.recordState('Connected');
+    tracker.markDisrupted();
+    // hook's own resubscribe wins the race...
+    expect(tracker.recordSubscriptionEstablished()).toBe(true);
+    // ...then the Hub reports Connected for the same recovery: no double fire
+    expect(tracker.recordState('Connected')).toBe(false);
+  });
+
+  it('requests catch-up after a forced reconnect gap (W1)', () => {
+    const tracker = new ConnectionHealthTracker();
+    tracker.recordState('Connected');
+    // visibilitychange / online handler closes and reopens the subscription
+    tracker.markDisrupted();
+    expect(tracker.recordSubscriptionEstablished()).toBe(true);
+  });
+});
+
+describe('reconnectDelayMs', () => {
+  it('grows exponentially from 1s', () => {
+    expect(reconnectDelayMs(0)).toBe(1000);
+    expect(reconnectDelayMs(1)).toBe(2000);
+    expect(reconnectDelayMs(2)).toBe(4000);
+    expect(reconnectDelayMs(3)).toBe(8000);
+  });
+
+  it('caps at 30s', () => {
+    expect(reconnectDelayMs(5)).toBe(30_000);
+    expect(reconnectDelayMs(100)).toBe(30_000);
+  });
+
+  it('handles negative attempts defensively', () => {
+    expect(reconnectDelayMs(-1)).toBe(1000);
+  });
+});
+
+describe('shouldReconnectOnVisible', () => {
+  it('skips a quick alt-tab while healthy', () => {
+    expect(shouldReconnectOnVisible(false, MIN_HIDDEN_DURATION_FOR_RECONNECT_MS - 1)).toBe(false);
+  });
+
+  it('reconnects after a long background period', () => {
+    expect(shouldReconnectOnVisible(false, MIN_HIDDEN_DURATION_FOR_RECONNECT_MS)).toBe(true);
+  });
+
+  it('always reconnects immediately when the connection is known-disrupted', () => {
+    expect(shouldReconnectOnVisible(true, 0)).toBe(true);
+  });
+
+  it('treats an unknown hidden duration (never hidden) as short', () => {
+    expect(shouldReconnectOnVisible(false, 0)).toBe(false);
+  });
+});

--- a/packages/webapp/src/lib/realtime-connection.ts
+++ b/packages/webapp/src/lib/realtime-connection.ts
@@ -1,0 +1,132 @@
+// Pure logic for monitoring the health of the AppSync Events WebSocket
+// connection (kept free of aws-amplify imports so it is unit-testable in a
+// node environment).
+//
+// Background: AppSync Events has no replay/catch-up — events published while
+// the socket is down are lost forever. The Amplify client detects silent
+// (half-open) disconnects via keep-alive monitoring and re-establishes the
+// socket + subscriptions on its own, but it cannot recover the lost events.
+// This tracker watches the CONNECTION_STATE_CHANGE Hub events and tells the
+// caller when a reconciliation with server-side data is needed.
+
+// Values mirror the `ConnectionState` enum exported from 'aws-amplify/data'.
+export type RealtimeConnectionState =
+  | 'Connected'
+  | 'ConnectedPendingNetwork'
+  | 'ConnectionDisrupted'
+  | 'ConnectionDisruptedPendingNetwork'
+  | 'Connecting'
+  | 'ConnectedPendingDisconnect'
+  | 'Disconnected'
+  | 'ConnectedPendingKeepAlive';
+
+// States that always indicate a real connectivity problem, regardless of
+// whether we were connected before (e.g. mounting while offline).
+const LOSSY_STATES: ReadonlySet<string> = new Set([
+  'ConnectionDisrupted',
+  'ConnectionDisruptedPendingNetwork',
+  'ConnectedPendingNetwork',
+  'ConnectedPendingKeepAlive',
+]);
+
+// States that are part of the normal connect/teardown sequence and only
+// indicate potential event loss when they happen after a successful
+// connection (the connection state monitor starts at 'Disconnected').
+const LOSSY_STATES_AFTER_CONNECTED: ReadonlySet<string> = new Set(['Disconnected', 'ConnectedPendingDisconnect']);
+
+export class ConnectionHealthTracker {
+  private wasConnected = false;
+  private disrupted = false;
+
+  /**
+   * Record a connection state change.
+   * @returns true when connectivity has just recovered after a period where
+   * events may have been lost — i.e. the caller should reconcile its state
+   * from the server now.
+   */
+  recordState(state: string): boolean {
+    if (state === 'Connected') {
+      const catchUpNeeded = this.disrupted;
+      this.wasConnected = true;
+      this.disrupted = false;
+      return catchUpNeeded;
+    }
+    if (LOSSY_STATES.has(state) || (this.wasConnected && LOSSY_STATES_AFTER_CONNECTED.has(state))) {
+      this.disrupted = true;
+    }
+    return false;
+  }
+
+  /**
+   * Record a disruption that the connection state monitor cannot see, e.g. a
+   * subscription rejected with EVENT_SUBSCRIBE_ERROR / GQL_ERROR (the socket
+   * stays open so no lossy Hub state is emitted, `observer.error` just
+   * fires) or the deliberate unsubscribe→resubscribe gap during a forced
+   * reconnect. Events published until the subscription is re-established are
+   * lost, so a catch-up must follow.
+   */
+  markDisrupted(): void {
+    this.disrupted = true;
+  }
+
+  /**
+   * Record that a subscription was (re-)established by the hook's own
+   * connect/retry path (as opposed to the Hub reporting 'Connected').
+   * @returns true when the caller should reconcile from the server because
+   * events may have been lost since the disruption. The flag is shared with
+   * `recordState` so whichever recovery signal arrives first wins and the
+   * catch-up fires exactly once per disruption.
+   */
+  recordSubscriptionEstablished(): boolean {
+    const catchUpNeeded = this.disrupted;
+    this.wasConnected = true;
+    this.disrupted = false;
+    return catchUpNeeded;
+  }
+
+  /** Whether events may currently be getting lost. */
+  get isDisrupted(): boolean {
+    return this.disrupted;
+  }
+}
+
+/**
+ * Exponential backoff for re-establishing a failed subscription:
+ * 1s, 2s, 4s, ... capped at 30s.
+ */
+export const reconnectDelayMs = (attempt: number): number => {
+  return Math.min(1000 * 2 ** Math.max(0, attempt), 30_000);
+};
+
+/**
+ * While the connection is known-unhealthy, consumers reconcile with the
+ * server at this interval so the UI stays usable even before the socket
+ * recovers (the Amplify client can take up to 5 minutes to hard-recover a
+ * half-open socket via its keep-alive timeout).
+ */
+export const CATCH_UP_POLL_INTERVAL_MS = 30_000;
+
+/**
+ * Minimum time a page must have been hidden for a visibilitychange-to-visible
+ * event to force a reconnect. Every forced reconnect deliberately marks the
+ * connection disrupted, which makes the following resubscribe fire the
+ * consumer's catch-up (typically a full `router.refresh()`), so an
+ * unthrottled handler re-fetches the whole RSC payload on every quick
+ * alt-tab. Gating on the *hidden duration* (rather than time since the last
+ * reconnect) keeps long background periods — where mobile browsers freeze
+ * sockets and events are likely lost — reconnecting immediately, with no
+ * blind window: a brief hide almost certainly kept the socket alive, and if
+ * it did silently die the Amplify keep-alive monitor still detects it and
+ * the CONNECTION_STATE_CHANGE path triggers the reconcile.
+ */
+export const MIN_HIDDEN_DURATION_FOR_RECONNECT_MS = 30_000;
+
+/**
+ * Decide whether a visibilitychange-to-visible event should force a
+ * reconnect now. Always reconnect when the connection is already known to be
+ * disrupted (that path needs the fastest possible recovery); otherwise only
+ * when the page was hidden long enough that the socket plausibly died.
+ */
+export const shouldReconnectOnVisible = (isDisrupted: boolean, hiddenDurationMs: number): boolean => {
+  return isDisrupted || hiddenDurationMs >= MIN_HIDDEN_DURATION_FOR_RECONNECT_MS;
+};


### PR DESCRIPTION
## Summary

Add connection health tracking and automatic catch-up recovery for the webapp's realtime WebSocket subscription, preventing silent message loss during network disruptions.

## Motivation

When the WebSocket connection drops (network switch, laptop sleep, mobile background), messages published during the gap are silently lost. The user sees a stale UI until they manually refresh. This is especially problematic for long-running agent sessions where the user may tab away and return later.

## Changes

- **Connection health tracker** (`packages/webapp/src/lib/realtime-connection.ts`): State machine that detects connection disruptions (via Hub events, keep-alive timeout, visibility API) and triggers exactly-once catch-up when the connection recovers
- **Event bus integration** (`packages/webapp/src/hooks/use-event-bus.ts`): Wire the health tracker into the existing subscription lifecycle; add exponential backoff reconnect with `reconnectDelayMs` and visibility-based reconnect via `shouldReconnectOnVisible`
- 3 files changed, +418 / -11 lines

## Testing

- 18 unit tests covering:
  - Initial connect (no false catch-up)
  - Recovery after network drop, keep-alive timeout, subscription error, forced reconnect, and visibility change
  - Exactly-once catch-up guarantee (no duplicates)
  - Exponential backoff delay calculation (1s → 30s cap)
  - Visibility-based reconnect heuristics (quick alt-tab skip vs. long background)
- `npm run build` (tsc) passes for webapp

## Notes

This is a self-contained change. The reconnect logic is additive and does not change the existing event subscription API surface. Recommended to merge before #5 (Deployment Recovery) as that feature complements this one for full resilience.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
