### PR TITLE
feat(webapp): auto-recover from stale deployments and add SW caching

### DIFF
--- a/packages/webapp/public/sw.js
+++ b/packages/webapp/public/sw.js
@@ -5,7 +5,7 @@ self.addEventListener('push', (event) => {
     const data = event.data.json();
     const options = {
       body: data.body || '',
-      icon: '/icon-192x192.png',
+      icon: data.icon || '/icon-192x192.png',
       badge: '/icon-192x192.png',
       data: {
         url: data.url || '/',
@@ -18,9 +18,17 @@ self.addEventListener('push', (event) => {
     const badgeInfo = data.badge;
     let badgePromise = Promise.resolve();
     if ('setAppBadge' in self.navigator && badgeInfo) {
-      const totalUnread = (badgeInfo.pendingCount || 0) + (badgeInfo.hasOtherUnread ? 1 : 0);
+      // Prefer server-computed totalUnread (consistent with the in-app bell
+      // badge). Fall back to the legacy pendingCount/hasOtherUnread fields for
+      // payloads emitted before totalUnread was introduced.
+      const totalUnread =
+        typeof badgeInfo.totalUnread === 'number'
+          ? badgeInfo.totalUnread
+          : (badgeInfo.pendingCount || 0) + (badgeInfo.hasOtherUnread ? 1 : 0);
       if (totalUnread > 0) {
         badgePromise = self.navigator.setAppBadge(totalUnread);
+      } else if ('clearAppBadge' in self.navigator) {
+        badgePromise = self.navigator.clearAppBadge();
       }
     }
 
@@ -55,7 +63,13 @@ self.addEventListener('message', (event) => {
   if (event.data && event.data.type === 'UPDATE_BADGE') {
     const badgeInfo = event.data.badge;
     if ('setAppBadge' in self.navigator) {
-      const totalUnread = (badgeInfo?.pendingCount || 0) + (badgeInfo?.hasOtherUnread ? 1 : 0);
+      // Prefer server-computed totalUnread (consistent with the in-app bell
+      // badge). Fall back to the legacy pendingCount/hasOtherUnread fields for
+      // payloads emitted before totalUnread was introduced.
+      const totalUnread =
+        typeof badgeInfo?.totalUnread === 'number'
+          ? badgeInfo.totalUnread
+          : (badgeInfo?.pendingCount || 0) + (badgeInfo?.hasOtherUnread ? 1 : 0);
       if (totalUnread > 0) {
         self.navigator.setAppBadge(totalUnread);
       } else if ('clearAppBadge' in self.navigator) {
@@ -65,10 +79,180 @@ self.addEventListener('message', (event) => {
   }
 });
 
+// ---------------------------------------------------------------------------
+// Caching (added for mobile/slow-network performance)
+//
+// Strategy per request type:
+// - /_next/static/**  : cache-first. Files are content-hashed and immutable,
+//   so a cached copy is always correct. Old-build chunks stay cached, which
+//   keeps a cached (stale) HTML page functional even offline.
+// - navigations (HTML): network-first with a timeout fallback to the last
+//   cached copy of the same URL. On a healthy network users always get fresh
+//   HTML (no version skew), while offline / very slow connections render the
+//   previous page instead of a browser error. Redirected or non-OK responses
+//   are never cached so auth redirects (/sign-in) cannot poison the cache
+//   (navigation fetches use redirect mode 'manual', so redirects surface as
+//   uncacheable opaqueredirect responses). A navigation request for /sign-in
+//   itself additionally purges the whole page cache: cached HTML is
+//   authenticated content, so it must not outlive the session (sign-out and
+//   cookie expiry both funnel into this navigation via the middleware
+//   redirect).
+// - icons / manifest  : stale-while-revalidate (cosmetic, safe when stale).
+// - everything else (API, RSC payload fetches, server actions, cross-origin):
+//   network only — deliberately NOT cached. Serving stale HTML on healthy
+//   networks (full stale-while-revalidate for navigations) was rejected
+//   because right after a deploy it would reference deleted chunks and fight
+//   the ChunkLoadError->reload recovery in DeploymentRecoveryListener.
+// ---------------------------------------------------------------------------
+
+const CACHE_VERSION = 'v1';
+const STATIC_CACHE = `static-${CACHE_VERSION}`;
+const PAGE_CACHE = `pages-${CACHE_VERSION}`;
+const ASSET_CACHE = `assets-${CACHE_VERSION}`;
+const KNOWN_CACHES = [STATIC_CACHE, PAGE_CACHE, ASSET_CACHE];
+const NAVIGATION_NETWORK_TIMEOUT_MS = 3000;
+// Growth bounds. Entries are evicted oldest-inserted-first once a cache
+// exceeds its limit (Cache.keys() returns entries in insertion order).
+const PAGE_CACHE_MAX_ENTRIES = 50;
+const STATIC_CACHE_MAX_ENTRIES = 300;
+const ASSET_CACHE_MAX_ENTRIES = 50;
+
+const timeout = (ms) =>
+  new Promise((resolve) => {
+    setTimeout(() => resolve(undefined), ms);
+  });
+
+async function trimCache(cache, maxEntries) {
+  const keys = await cache.keys();
+  if (keys.length <= maxEntries) return;
+  await Promise.all(keys.slice(0, keys.length - maxEntries).map((key) => cache.delete(key)));
+}
+
+function putAndTrim(cache, request, response, maxEntries) {
+  cache
+    .put(request, response)
+    .then(() => trimCache(cache, maxEntries))
+    .catch(() => {});
+}
+
+// All cached page HTML is authenticated content. When authentication ends —
+// observed as a navigation request for /sign-in (sign-out, cookie expiry and
+// direct visits all land here via the middleware redirect) — purge it so the
+// next visitor on this browser can never be served another user's cached
+// pages.
+async function purgePageCache() {
+  const cache = await caches.open(PAGE_CACHE);
+  const keys = await cache.keys();
+  await Promise.all(keys.map((key) => cache.delete(key)));
+}
+
+async function cacheFirst(request, cacheName, maxEntries) {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request);
+  if (cached) return cached;
+  const response = await fetch(request);
+  if (response.ok && !response.redirected) {
+    putAndTrim(cache, request, response.clone(), maxEntries);
+  }
+  return response;
+}
+
+async function staleWhileRevalidate(request, cacheName, maxEntries) {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request);
+  const network = fetch(request)
+    .then((response) => {
+      if (response.ok && !response.redirected) {
+        putAndTrim(cache, request, response.clone(), maxEntries);
+      }
+      return response;
+    })
+    .catch(() => undefined);
+  return cached || (await network) || fetch(request);
+}
+
+async function networkFirstNavigation(request) {
+  const cache = await caches.open(PAGE_CACHE);
+  const networkPromise = fetch(request)
+    .then((response) => {
+      // Navigation requests have redirect mode 'manual', so an auth redirect
+      // surfaces here as an opaqueredirect response (status 0, ok=false,
+      // redirected=false) and is never cached by this guard. The sign-out
+      // purge happens in the fetch handler when the browser follows the
+      // redirect and issues the /sign-in navigation.
+      if (response.ok && !response.redirected && new URL(request.url).pathname.indexOf('/api/') !== 0) {
+        putAndTrim(cache, request, response.clone(), PAGE_CACHE_MAX_ENTRIES);
+      }
+      return response;
+    })
+    .catch(() => undefined);
+
+  // Serve fresh HTML when the network answers quickly; fall back to the last
+  // cached copy on slow/offline networks while the fetch keeps running in the
+  // background to refresh the cache for next time.
+  const winner = await Promise.race([networkPromise, timeout(NAVIGATION_NETWORK_TIMEOUT_MS)]);
+  if (winner) return winner;
+
+  const cached = await cache.match(request);
+  if (cached) return cached;
+
+  const network = await networkPromise;
+  if (network) return network;
+  return fetch(request);
+}
+
+self.addEventListener('fetch', (event) => {
+  const request = event.request;
+  if (request.method !== 'GET') return;
+
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) return;
+
+  if (url.pathname.startsWith('/_next/static/')) {
+    event.respondWith(cacheFirst(request, STATIC_CACHE, STATIC_CACHE_MAX_ENTRIES).catch(() => fetch(request)));
+    return;
+  }
+
+  if (request.mode === 'navigate') {
+    // Any navigation that lands on /sign-in means the session is no longer
+    // authenticated (sign-out, cookie expiry, and direct visits all converge
+    // here: the middleware redirects every unauthenticated navigation to
+    // /sign-in, and the browser re-issues that redirect as a fresh navigation
+    // request through this handler). Cached page HTML is authenticated
+    // content, so drop it all before the next user can be served it.
+    if (url.pathname === '/sign-in') {
+      event.waitUntil(purgePageCache().catch(() => {}));
+    }
+    event.respondWith(networkFirstNavigation(request).catch(() => fetch(request)));
+    return;
+  }
+
+  if (
+    url.pathname === '/manifest.json' ||
+    url.pathname === '/api/manifest' ||
+    url.pathname.startsWith('/api/agent-icon') ||
+    /^\/icon-\d+x\d+\.png$/.test(url.pathname)
+  ) {
+    event.respondWith(staleWhileRevalidate(request, ASSET_CACHE, ASSET_CACHE_MAX_ENTRIES).catch(() => fetch(request)));
+    return;
+  }
+  // All other requests (RSC payload fetches, API calls, ...) fall through to
+  // the network untouched.
+});
+
 self.addEventListener('install', (event) => {
   self.skipWaiting();
 });
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(clients.claim());
+  event.waitUntil(
+    Promise.all([
+      clients.claim(),
+      caches
+        .keys()
+        .then((keys) =>
+          Promise.all(keys.filter((key) => !KNOWN_CACHES.includes(key)).map((key) => caches.delete(key)))
+        ),
+    ])
+  );
 });

--- a/packages/webapp/src/components/DeploymentRecoveryListener.tsx
+++ b/packages/webapp/src/components/DeploymentRecoveryListener.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect } from 'react';
+import { toast } from 'sonner';
+import { useTranslations } from 'next-intl';
+import { classifyStaleDeploymentError, reloadForStaleDeployment } from '@/lib/deployment-recovery';
+
+/**
+ * Global safety net for stale-deployment failures that are not handled by a
+ * specific form. next-safe-action hooks re-throw Server Action errors after
+ * their callbacks, and `<form onSubmit>` does not await the handler promise,
+ * so EVERY form's stale-action failure surfaces here as an unhandled
+ * rejection — including forms that hold unsaved user input (CustomAgentForm,
+ * GlobalPreferencesForm, ...).
+ *
+ * Therefore this listener never reloads on a stale ACTION error: an automatic
+ * reload would silently destroy that unsaved input. It only
+ *  - reloads for ChunkLoadError (the page is already missing code, so a
+ *    reload cannot make things worse), and
+ *  - shows an "app was updated, please reload" toast otherwise, so a failed
+ *    save is never a silent dead button.
+ * Forms that persist their pending submission for auto-resend (MessageForm /
+ * NewSessionForm) reload themselves; `classifyStaleDeploymentError` detects
+ * that in-flight reload and keeps this listener quiet ('defer').
+ */
+export default function DeploymentRecoveryListener() {
+  const t = useTranslations('common.deploymentRecovery');
+
+  useEffect(() => {
+    const RELOAD_DELAY_MS = 250;
+    const notify = () => {
+      toast.warning(t('appUpdated'), {
+        id: 'stale-deployment-notice',
+        duration: 10_000,
+        action: {
+          label: t('reload'),
+          onClick: () => window.location.reload(),
+        },
+      });
+    };
+    const handle = (error: unknown): boolean => {
+      const decision = classifyStaleDeploymentError(error, window.sessionStorage);
+      if (decision === 'ignore') return false;
+      if (decision === 'reload') {
+        // Defer slightly so a component-level handler observing the same
+        // failure gets to run first; the loop guard inside
+        // reloadForStaleDeployment makes double-firing a no-op.
+        window.setTimeout(() => {
+          if (!reloadForStaleDeployment()) notify();
+        }, RELOAD_DELAY_MS);
+      } else if (decision === 'notify') {
+        notify();
+      }
+      return true;
+    };
+    const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+      if (handle(event.reason)) event.preventDefault();
+    };
+    const onError = (event: ErrorEvent) => {
+      if (handle(event.error)) event.preventDefault();
+    };
+    window.addEventListener('unhandledrejection', onUnhandledRejection);
+    window.addEventListener('error', onError);
+    return () => {
+      window.removeEventListener('unhandledrejection', onUnhandledRejection);
+      window.removeEventListener('error', onError);
+    };
+  }, [t]);
+
+  return null;
+}

--- a/packages/webapp/src/lib/deployment-recovery.test.ts
+++ b/packages/webapp/src/lib/deployment-recovery.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+// Deep import into Next.js internals: there is no public export of the
+// UnrecognizedActionError class itself (only the unstable type guard in
+// 'next/navigation'). Re-verify this path when upgrading Next.js.
+import { UnrecognizedActionError } from 'next/dist/client/components/unrecognized-action-error';
+import {
+  FORM_RECOVERY_IN_FLIGHT_MS,
+  RELOAD_ATTEMPTS_RESET_MS,
+  RELOAD_GUARD_WINDOW_MS,
+  RELOAD_MAX_ATTEMPTS,
+  canReloadForStaleDeployment,
+  classifyStaleDeploymentError,
+  clearStaleDeploymentReloadGuard,
+  isChunkLoadError,
+  isStaleActionError,
+  markStaleDeploymentReload,
+  type KeyValueStorage,
+} from './deployment-recovery';
+
+function fakeStorage(): KeyValueStorage {
+  const map = new Map<string, string>();
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k)! : null),
+    setItem: (k, v) => void map.set(k, v),
+    removeItem: (k) => void map.delete(k),
+  };
+}
+
+function staleActionError() {
+  return new UnrecognizedActionError('Server Action "deadbeef" was not found on the server.');
+}
+
+function chunkLoadError() {
+  const error = new Error('Loading chunk 123 failed.');
+  error.name = 'ChunkLoadError';
+  return error;
+}
+
+describe('isStaleActionError', () => {
+  it('detects UnrecognizedActionError thrown for stale Server Action IDs', () => {
+    expect(isStaleActionError(staleActionError())).toBe(true);
+  });
+
+  it('does not match ordinary errors or chunk errors', () => {
+    expect(isStaleActionError(new Error('Session not found'))).toBe(false);
+    expect(isStaleActionError(chunkLoadError())).toBe(false);
+    expect(isStaleActionError('Failed to find Server Action')).toBe(false);
+    expect(isStaleActionError(undefined)).toBe(false);
+    expect(isStaleActionError(null)).toBe(false);
+  });
+});
+
+describe('isChunkLoadError', () => {
+  it('detects webpack chunk load errors by name', () => {
+    expect(isChunkLoadError(chunkLoadError())).toBe(true);
+  });
+
+  it('detects chunk load errors by message when name is generic', () => {
+    expect(isChunkLoadError(new Error('Loading chunk app/foo failed. (error: https://x/chunk.js)'))).toBe(true);
+    expect(isChunkLoadError(new Error('Loading CSS chunk 42 failed.'))).toBe(true);
+  });
+
+  it('does not match ordinary errors or stale action errors', () => {
+    expect(isChunkLoadError(new Error('Session not found'))).toBe(false);
+    expect(isChunkLoadError(staleActionError())).toBe(false);
+  });
+
+  it('handles non-object inputs safely', () => {
+    expect(isChunkLoadError('ChunkLoadError')).toBe(false);
+    expect(isChunkLoadError(42)).toBe(false);
+  });
+});
+
+describe('reload loop guard', () => {
+  it('allows the first reload and blocks reloads within the guard window', () => {
+    const storage = fakeStorage();
+    const t0 = 1_000_000;
+    expect(canReloadForStaleDeployment(storage, t0)).toBe(true);
+    markStaleDeploymentReload(storage, t0);
+    expect(canReloadForStaleDeployment(storage, t0 + 1)).toBe(false);
+    expect(canReloadForStaleDeployment(storage, t0 + RELOAD_GUARD_WINDOW_MS - 1)).toBe(false);
+  });
+
+  it('allows a reload again after the guard window has passed', () => {
+    const storage = fakeStorage();
+    const t0 = 1_000_000;
+    markStaleDeploymentReload(storage, t0);
+    expect(canReloadForStaleDeployment(storage, t0 + RELOAD_GUARD_WINDOW_MS)).toBe(true);
+  });
+
+  it('caps the number of automatic reload attempts (no indefinite reloading)', () => {
+    const storage = fakeStorage();
+    let now = 1_000_000;
+    for (let attempt = 0; attempt < RELOAD_MAX_ATTEMPTS; attempt++) {
+      expect(canReloadForStaleDeployment(storage, now)).toBe(true);
+      markStaleDeploymentReload(storage, now);
+      now += RELOAD_GUARD_WINDOW_MS;
+    }
+    // The next attempt after the sliding window is denied by the hard cap.
+    expect(canReloadForStaleDeployment(storage, now)).toBe(false);
+    expect(canReloadForStaleDeployment(storage, now + RELOAD_GUARD_WINDOW_MS)).toBe(false);
+  });
+
+  it('resets the attempt counter after the reset horizon', () => {
+    const storage = fakeStorage();
+    let now = 1_000_000;
+    for (let attempt = 0; attempt < RELOAD_MAX_ATTEMPTS; attempt++) {
+      markStaleDeploymentReload(storage, now);
+      now += RELOAD_GUARD_WINDOW_MS;
+    }
+    expect(canReloadForStaleDeployment(storage, now)).toBe(false);
+    expect(canReloadForStaleDeployment(storage, now + RELOAD_ATTEMPTS_RESET_MS)).toBe(true);
+  });
+
+  it('resets the attempt counter when cleared (e.g. after a successful send)', () => {
+    const storage = fakeStorage();
+    let now = 1_000_000;
+    for (let attempt = 0; attempt < RELOAD_MAX_ATTEMPTS; attempt++) {
+      markStaleDeploymentReload(storage, now);
+      now += RELOAD_GUARD_WINDOW_MS;
+    }
+    expect(canReloadForStaleDeployment(storage, now)).toBe(false);
+    clearStaleDeploymentReloadGuard(storage);
+    expect(canReloadForStaleDeployment(storage, now)).toBe(true);
+  });
+
+  it('treats a corrupted guard value as reloadable', () => {
+    const storage = fakeStorage();
+    storage.setItem('stale-deployment-reload-guard', 'not-json{');
+    expect(canReloadForStaleDeployment(storage, 123)).toBe(true);
+    storage.setItem('stale-deployment-reload-guard', JSON.stringify({ at: 'nope' }));
+    expect(canReloadForStaleDeployment(storage, 123)).toBe(true);
+  });
+
+  it('fails closed (no reload) when storage throws', () => {
+    const storage: KeyValueStorage = {
+      getItem: () => {
+        throw new Error('denied');
+      },
+      setItem: () => {},
+      removeItem: () => {},
+    };
+    expect(canReloadForStaleDeployment(storage)).toBe(false);
+  });
+});
+
+describe('classifyStaleDeploymentError (global listener policy)', () => {
+  // B1 regression: an automatic reload on a stale ACTION error would destroy
+  // unsaved input in forms without pending-resend protection (CustomAgentForm
+  // etc.). The global policy must never answer 'reload' for that class.
+  it('never reloads for stale Server Action errors, even when the guard would allow it', () => {
+    const storage = fakeStorage();
+    expect(canReloadForStaleDeployment(storage, 1_000_000)).toBe(true);
+    expect(classifyStaleDeploymentError(staleActionError(), storage, 1_000_000)).toBe('notify');
+  });
+
+  it('notifies (never silently drops) stale action errors repeated within the guard window', () => {
+    const storage = fakeStorage();
+    const t0 = 1_000_000;
+    markStaleDeploymentReload(storage, t0);
+    const later = t0 + FORM_RECOVERY_IN_FLIGHT_MS;
+    expect(classifyStaleDeploymentError(staleActionError(), storage, later)).toBe('notify');
+  });
+
+  it('defers to a form-level recovery reload initiated moments ago', () => {
+    const storage = fakeStorage();
+    const t0 = 1_000_000;
+    markStaleDeploymentReload(storage, t0);
+    expect(classifyStaleDeploymentError(staleActionError(), storage, t0 + 100)).toBe('defer');
+    expect(classifyStaleDeploymentError(chunkLoadError(), storage, t0 + 100)).toBe('defer');
+  });
+
+  it('reloads for chunk load errors when the guard allows it', () => {
+    const storage = fakeStorage();
+    expect(classifyStaleDeploymentError(chunkLoadError(), storage, 1_000_000)).toBe('reload');
+  });
+
+  it('falls back to notify when the guard blocks a chunk-error reload', () => {
+    const storage = fakeStorage();
+    const t0 = 1_000_000;
+    markStaleDeploymentReload(storage, t0);
+    const withinWindow = t0 + FORM_RECOVERY_IN_FLIGHT_MS + 1;
+    expect(classifyStaleDeploymentError(chunkLoadError(), storage, withinWindow)).toBe('notify');
+  });
+
+  it('ignores ordinary errors (validation, permission, network)', () => {
+    const storage = fakeStorage();
+    expect(classifyStaleDeploymentError(new Error('Session not found'), storage, 1_000_000)).toBe('ignore');
+    expect(classifyStaleDeploymentError(undefined, storage, 1_000_000)).toBe('ignore');
+    expect(classifyStaleDeploymentError('boom', storage, 1_000_000)).toBe('ignore');
+  });
+});

--- a/packages/webapp/src/lib/deployment-recovery.ts
+++ b/packages/webapp/src/lib/deployment-recovery.ts
@@ -1,0 +1,172 @@
+import { unstable_isUnrecognizedActionError } from 'next/navigation';
+
+/**
+ * Recovery helpers for "version skew" failures: a browser tab that loaded an
+ * older build keeps POSTing Server Action IDs (and lazily fetching JS chunks)
+ * that no longer exist after the webapp is redeployed. Next.js salts every
+ * Server Action ID with a per-build random encryption key, so a redeploy
+ * invalidates ALL action IDs held by open tabs — the server answers
+ * 404 + `x-nextjs-action-not-found` and the client throws
+ * `UnrecognizedActionError` without ever executing the action.
+ *
+ * Two distinct failure classes with different guarantees:
+ *
+ * - `isStaleActionError` (UnrecognizedActionError): the server rejected the
+ *   action ID BEFORE executing it, so the action is guaranteed not to have
+ *   run. This is the only class where an automatic re-submission after a
+ *   reload can never cause a double-send.
+ * - `isChunkLoadError`: a JS/CSS chunk of the old build failed to load. This
+ *   says nothing about whether an in-flight action executed, so callers must
+ *   never auto-resubmit on this class — at most reload (the page is already
+ *   broken) or restore the user's input without submitting.
+ */
+
+const RELOAD_GUARD_KEY = 'stale-deployment-reload-guard';
+export const RELOAD_GUARD_WINDOW_MS = 30_000;
+/** Hard cap on automatic reload attempts within one "episode" (S3). */
+export const RELOAD_MAX_ATTEMPTS = 3;
+/** After this long without another reload attempt, the attempt counter resets. */
+export const RELOAD_ATTEMPTS_RESET_MS = 10 * 60_000;
+/**
+ * How recently a reload must have been initiated for the global listener to
+ * treat a stale error as "a form-level recovery handler is already reloading
+ * this page" and stay silent instead of showing its own notice.
+ */
+export const FORM_RECOVERY_IN_FLIGHT_MS = 2_000;
+
+export interface KeyValueStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export function isChunkLoadError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const { name, message } = error as { name?: unknown; message?: unknown };
+  if (name === 'ChunkLoadError' || name === 'CssChunkLoadError') return true;
+  return typeof message === 'string' && /Loading (?:CSS )?chunk .+ failed/i.test(message);
+}
+
+/**
+ * True when the error is Next.js's UnrecognizedActionError — the server
+ * received a Server Action ID it does not know (stale build after a
+ * redeploy) and rejected the request with 404 before executing anything.
+ *
+ * NOTE: `unstable_isUnrecognizedActionError` is an unstable Next.js API
+ * (added in Next 15/16 for exactly this version-skew scenario). When
+ * upgrading Next.js, verify it still exists and still matches the error
+ * thrown by the Server Action client reference on 404 +
+ * `x-nextjs-action-not-found`.
+ */
+export function isStaleActionError(error: unknown): boolean {
+  return unstable_isUnrecognizedActionError(error);
+}
+
+type ReloadGuardState = { at: number; count: number };
+
+function readGuard(storage: KeyValueStorage): ReloadGuardState | null {
+  const raw = storage.getItem(RELOAD_GUARD_KEY);
+  if (raw === null) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    const { at, count } = parsed as { at?: unknown; count?: unknown };
+    if (typeof at !== 'number' || !Number.isFinite(at)) return null;
+    return { at, count: typeof count === 'number' && Number.isFinite(count) ? count : 1 };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether an automatic reload is currently allowed. Two independent brakes
+ * prevent reload loops:
+ *  1. a sliding window (`RELOAD_GUARD_WINDOW_MS`) between attempts, and
+ *  2. a hard cap (`RELOAD_MAX_ATTEMPTS`) on attempts per episode — without
+ *     it, an environment that keeps serving the stale HTML from cache could
+ *     reload every 30 seconds indefinitely.
+ * The episode ends (counter resets) after `RELOAD_ATTEMPTS_RESET_MS` without
+ * attempts, or when `clearStaleDeploymentReloadGuard` is called on a
+ * successful submission.
+ */
+export function canReloadForStaleDeployment(storage: KeyValueStorage, now = Date.now()): boolean {
+  try {
+    const guard = readGuard(storage);
+    if (!guard) return true;
+    if (now - guard.at >= RELOAD_ATTEMPTS_RESET_MS) return true;
+    if (now - guard.at < RELOAD_GUARD_WINDOW_MS) return false;
+    return guard.count < RELOAD_MAX_ATTEMPTS;
+  } catch {
+    return false;
+  }
+}
+
+export function markStaleDeploymentReload(storage: KeyValueStorage, now = Date.now()): void {
+  try {
+    const guard = readGuard(storage);
+    const count = guard && now - guard.at < RELOAD_ATTEMPTS_RESET_MS ? guard.count + 1 : 1;
+    storage.setItem(RELOAD_GUARD_KEY, JSON.stringify({ at: now, count } satisfies ReloadGuardState));
+  } catch {}
+}
+
+/** Reset the reload attempt counter, e.g. after a successful submission. */
+export function clearStaleDeploymentReloadGuard(storage: KeyValueStorage): void {
+  try {
+    storage.removeItem(RELOAD_GUARD_KEY);
+  } catch {}
+}
+
+function isFormRecoveryReloadInFlight(storage: KeyValueStorage, now: number): boolean {
+  try {
+    const guard = readGuard(storage);
+    return guard !== null && now - guard.at >= 0 && now - guard.at < FORM_RECOVERY_IN_FLIGHT_MS;
+  } catch {
+    return false;
+  }
+}
+
+export type StaleDeploymentDecision = 'ignore' | 'defer' | 'reload' | 'notify';
+
+/**
+ * Decide how the GLOBAL listener should react to an uncaught error. This is
+ * deliberately conservative: forms that persist their pending submission
+ * (MessageForm / NewSessionForm) run their own reload + auto-resend, while
+ * every other surface must never be reloaded automatically on a stale action
+ * error — an automatic reload would silently destroy unsaved user input
+ * (e.g. a long system prompt in CustomAgentForm).
+ *
+ * - 'ignore': not a stale-deployment error; let default handling proceed.
+ * - 'defer': a form-level recovery handler already initiated a reload for
+ *   this failure; stay silent.
+ * - 'reload': ChunkLoadError only — the page is already broken (missing
+ *   code), so reloading cannot lose more than staying broken would.
+ * - 'notify': tell the user the app was updated and offer a manual reload;
+ *   never reload for them. Also the fallback when the reload guard blocks a
+ *   ChunkLoadError reload, so repeated failures always produce visible
+ *   feedback instead of a dead button.
+ */
+export function classifyStaleDeploymentError(
+  error: unknown,
+  storage: KeyValueStorage,
+  now = Date.now()
+): StaleDeploymentDecision {
+  const chunk = isChunkLoadError(error);
+  if (!chunk && !isStaleActionError(error)) return 'ignore';
+  if (isFormRecoveryReloadInFlight(storage, now)) return 'defer';
+  if (chunk) return canReloadForStaleDeployment(storage, now) ? 'reload' : 'notify';
+  return 'notify';
+}
+
+/**
+ * Reload the page once to recover from a stale deployment. Returns true when
+ * the reload was initiated, false when it was suppressed by the loop guard.
+ * Callers that get `false` should fall back to their normal error handling.
+ */
+export function reloadForStaleDeployment(): boolean {
+  if (typeof window === 'undefined') return false;
+  const storage = window.sessionStorage;
+  if (!canReloadForStaleDeployment(storage)) return false;
+  markStaleDeploymentReload(storage);
+  window.location.reload();
+  return true;
+}

--- a/packages/webapp/src/messages/en.json
+++ b/packages/webapp/src/messages/en.json
@@ -1,6 +1,10 @@
 {
   "common": {
-    "locale": "English"
+    "locale": "English",
+    "deploymentRecovery": {
+      "appUpdated": "The app has been updated. Please reload the page to continue.",
+      "reload": "Reload"
+    }
   },
   "header": {
     "title": "Remote SWE Agents",

--- a/packages/webapp/src/messages/ja.json
+++ b/packages/webapp/src/messages/ja.json
@@ -1,6 +1,10 @@
 {
   "common": {
-    "locale": "日本語"
+    "locale": "日本語",
+    "deploymentRecovery": {
+      "appUpdated": "アプリが更新されました。続行するにはページを再読み込みしてください。",
+      "reload": "再読み込み"
+    }
   },
   "header": {
     "title": "Remote SWE Agents",


### PR DESCRIPTION
## Summary

Add automatic detection and recovery from stale deployment errors (Server Action ID mismatch, chunk load failures) with a service worker caching layer for static assets.

## Motivation

When the webapp is redeployed while users have active sessions, Next.js Server Action IDs become stale, and dynamically-loaded chunks return 404. Users see mysterious "unhandled rejection" errors or broken UIs with no indication that a simple reload would fix the problem. This is especially common in agent-driven workflows where sessions run for hours.

## Changes

- **Deployment recovery logic** (`packages/webapp/src/lib/deployment-recovery.ts`): Error classification (`isStaleActionError`, `isChunkLoadError`), reload loop guard (max attempts with time-based reset), and `classifyStaleDeploymentError` policy function
- **Global error listener** (`packages/webapp/src/components/DeploymentRecoveryListener.tsx`): Catches unhandled rejections and applies the recovery policy — auto-reloads for chunk errors, shows a toast notification for stale action errors (to avoid destroying unsaved form input)
- **Service worker** (`packages/webapp/public/sw.js`): Stale-while-revalidate caching for static assets (JS/CSS chunks, images) so users don't hit 404 during deployment transitions
- **i18n messages** (`en.json`, `ja.json`): User-facing toast messages for the "app was updated" notification
- 6 files changed, +633 / -6 lines

## Testing

- 19 unit tests covering:
  - Error classification (stale action, chunk load, ordinary errors)
  - Reload loop guard (first reload allowed, guard window blocking, max attempts cap, reset horizon, storage errors)
  - Policy function (never auto-reload for stale actions, defers to form-level recovery, reloads for chunk errors when allowed)
- `npm run build` (tsc) passes for webapp

## Notes

This change is self-contained and can be merged independently. However, it complements PR #4 (Realtime Connection Recovery) — together they provide full resilience for both data-plane (WebSocket events) and code-plane (stale bundles) disruptions. Recommended merge order: #4 first, then #5.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
